### PR TITLE
Simplify type aliases in shared_types.py

### DIFF
--- a/.claude/skills/pr-create/SKILL.md
+++ b/.claude/skills/pr-create/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: pr-create
+description: Use this when creating a pull request
+---
+
+Your job is to create a clean, concise pull request that's easy to understand and easy to review
+
+- Make sure you're on a feature branch (NEVER the main branch), otherwise stop and ask the user for guidance
+- Make sure all workspace changes have been committed, otherwise stop and ask the user for guidance
+- Make sure the branch is pushed and origin and local are in sync
+- Create a pull request with a simple description
+    - Summarize the work done focusing on the "user-why" for the changes
+    - Be brief
+    - Use bulleted/numbered lists to convey key points and sequences
+    - **Do not include** details that are easily found in documentation or in github such as examples/contra-examples or specific algorithms
+    - **Do not include** acceptance criteria
+    - **Do not include** a test plan
+    - **Do not include** lists of changed files/lines
+    - **Do not include** verification steps
+    - [Optional] If there are backwards compatibility issues, risky code changes, or segments of the PR that need significant scrutiny from the reviewer create a **Key Concerns** section in the description - you typically won't need this

--- a/.claude/skills/ralph-code/SKILL.md
+++ b/.claude/skills/ralph-code/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: ralph-code
+description: Use this skill when developing code, especially during a TDD cycle. This is the "Green" phase of TDD
+---
+
+Implement the code to fulfill the task. If you have questions about what you're implementing 1) look at tests as they already should have been written, 2) look at SCOPES.md and DESIGN.md for the design you're implementing.
+
+Write the code to implement the task. Do not go beyond the definition of the task, other agents will be developing those features, stick to the task you are assigned.
+
+As you develop, after any significant piece of work is done you are permitted to commit your changes. Before commiting fix any linting errors.  Not all tests have to be passing for an in-progress commit.
+
+Do not update tests to fit your code unless they are significantly out of line. Use the tests as they are and make your code fit the tests.
+
+Your job is complete when: 1) All tests pass 2) All linting errors are fixed 3) all task acceptance criteria and the task description are satisfied
+
+Once all criteria are met:
+1. Ensure all tests are passing
+2. Update the current task in the SCOPES.yml file to assign a status of "implementing"
+3. Commit ALL remaining changes (including the status update) to VCS
+4. Call the ralph-refactor skill using the Skill tool with the same arguments that were passed to this skill

--- a/.claude/skills/ralph-next/SKILL.md
+++ b/.claude/skills/ralph-next/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: ralph-next
+description: Select and execute the next TDD task phase from SCOPES.yml
+---
+
+Your job is to select which task should be worked on next and execute the appropriate TDD skill for its current phase.
+
+## Selection Priority (highest to lowest)
+
+1. **In-progress tasks** - Tasks with status "testing" or "implementing" (work already started)
+2. **New tasks** - Tasks with status "scoped" that have all dependencies "completed"
+3. Never select tasks with status "completed"
+
+## Tie-breaking
+
+When multiple tasks have the same priority:
+- Prefer lower effort over higher effort
+- Prefer tasks appearing earlier in the file
+
+## Branch Handling
+
+Each task gets its own branch. The branch name is derived from the task:
+- Format: `task-<id>-<slugified-title>`
+- Example: Task 1 "Initialize Expo project" → `task-1-initialize-expo-project`
+
+The base branch for a task is determined by its milestone's `base_branch`:
+```yaml
+milestones:
+  - number: 1
+    title: "1. Foundation"
+    base_branch: main  # Tasks in milestone 1 branch from main
+
+tasks:
+  - id: 1
+    milestone: 1  # This task branches from main
+    ...
+```
+
+Before starting work on a task:
+1. Generate the task branch name: `task-<id>-<slugified-title>`
+2. Look up the task's milestone to get `base_branch`
+3. Check if the task branch exists locally
+4. If it exists, switch to that branch
+5. If it does NOT exist:
+   - Fetch the latest from origin
+   - Create the branch from `base_branch` (e.g., `git checkout -b task-1-init-expo origin/main`)
+   - Push the new branch to origin with tracking (`git push -u origin task-1-init-expo`)
+
+### Slugifying the title
+- Lowercase the title
+- Replace spaces with hyphens
+- Remove special characters
+- Truncate to ~50 chars max for readability
+
+## Workflow
+
+1. Read the SCOPES.yml file (full path provided in arguments)
+2. Select the highest priority task based on above rules
+3. Handle branch setup as described above (per-task branch)
+4. Based on the task's status, call the appropriate skill using the Skill tool:
+   - `"scoped"` -> call skill `ralph-test` with arguments: `<scopes-path> <task-id>`
+   - `"testing"` -> call skill `ralph-code` with arguments: `<scopes-path> <task-id>`
+   - `"implementing"` -> call skill `ralph-refactor` with arguments: `<scopes-path> <task-id>`
+5. If no tasks qualify, respond with "NO WORK"
+
+Execute the next skill immediately based on the task status or return "NO WORK" if there is nothing to work on.
+
+The ralph-test, ralph-code, and ralph-refactor skills automatically chain together and handle updating the task status after they complete their work. The ralph-refactor skill will call ralph-pr to create a PR for the completed task.

--- a/.claude/skills/ralph-pr/SKILL.md
+++ b/.claude/skills/ralph-pr/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: ralph-pr
+description: Use this skill to create a PR for a completed task
+---
+
+Your job is to create a pull request for a completed task.
+
+## Arguments
+
+This skill receives the same arguments as other ralph-* skills:
+- `<scopes-path>` - Path to the SCOPES.yml file
+- `<task-id>` - ID of the task that was just completed
+
+## Workflow
+
+1. Read the SCOPES.yml file
+2. Find the task with the given ID
+3. Get the task's milestone to determine the base branch (`base_branch`)
+4. Generate the task branch name: `task-<id>-<slugified-title>`
+5. Ensure all changes are committed and pushed to the task branch
+6. Create a PR using `gh pr create`:
+   - Title: Task title from SCOPES.yml
+   - Base: The milestone's `base_branch`
+   - Body should include:
+     - Reference to the issue: `Closes #<github_issue>`
+     - Summary of what was implemented
+     - The acceptance criteria from the task
+7. Report the PR URL
+
+## PR Format
+
+```
+## Summary
+<Brief description of what was implemented>
+
+## Acceptance Criteria
+- [x] Criterion 1
+- [x] Criterion 2
+...
+
+Closes #<github_issue>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+## Merging PRs
+
+**IMPORTANT:** When merging PRs, always use **squash and merge**. Never use regular merge or rebase.
+
+```bash
+gh pr merge <pr-number> --squash --delete-branch
+```
+
+This keeps the main branch history clean with one commit per task.
+
+## Example
+
+For Task 2 "Define theme constants" in Milestone 1 (base: main):
+- Branch: `task-2-define-theme-constants`
+- PR: `task-2-define-theme-constants` → `main`
+- Title: "Define theme constants and design tokens"
+- Body references: `Closes #2`
+- Merge: `gh pr merge --squash --delete-branch`

--- a/.claude/skills/ralph-refactor/SKILL.md
+++ b/.claude/skills/ralph-refactor/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: ralph-refactor
+description: Use this skill after a ralph-code phase has completed but before marking the task as complete in SCOPES.yml
+---
+
+Your job is to review the tests and the code that were written for this task, perform a security audit, and look for any needed rework.
+
+**IMPORTANT**: Do NOT use superpowers:code-reviewer or superpowers:requesting-code-review for this skill. Follow the phases below directly.
+
+## Phase 1: Code Quality Review
+
+Analyze the completed code and look for needed refactors. Don't be overly critical or nit-pick, look for changes that are worth putting extra effort into.
+
+**Code Smells**
+
+1. Duplication - Repeated logic or similar code blocks
+2. Long functions - Functions trying to do too much
+3. Complex conditionals - Deeply nested ifs or complex boolean expressions
+4. Magic numbers/strings - Hardcoded values without clear meaning
+5. Poor naming - Unclear variable, function, or type names
+
+**Design Issues**
+
+1. Violation of project standards - Code doesn't follow established conventions
+2. High coupling - Functions/modules with too many dependencies
+3. Low cohesion - Functions doing unrelated things
+4. Temporary hacks - Quick-fix code written just to make tests pass
+5. Hard to test code - Indicates poor separation of concerns
+
+## Phase 2: Security Audit
+
+**CRITICAL**: Before marking any task as complete, you MUST invoke the security-review skill using the Skill tool:
+
+```
+Skill tool call:
+  skill: "security-review"
+```
+
+Do NOT skip this step. Do NOT use superpowers:code-reviewer as a substitute.
+
+The security review should cover:
+
+1. **New code security** - Audit the code written for this task
+2. **Integration security** - How the new code fits with existing code and potential attack vectors
+
+If the security review identifies issues:
+
+- Critical/High severity: MUST be fixed before completing the task
+- Medium severity: Should be fixed, document if deferring with justification
+- Low severity: Fix if trivial, otherwise note for future improvement
+
+## When to Loop Back
+
+**CRITICAL** If code quality OR security issues are found:
+
+1. If the issue impacts function signatures or behavior, call the `ralph-test` skill to go back to the "Red" TDD phase
+2. If the issue is implementation quality or security fix that doesn't change behavior, call the `ralph-code` skill to go back to the "Green" TDD phase
+3. Do NOT update the status in SCOPES.yml - the called skill will handle status updates
+
+## When to Complete
+
+If NO issues are found (code is clean AND security audit passes):
+
+1. Ensure there are no uncommitted workspace changes (all modified code should be committed)
+2. Update the current task in the SCOPES.yml file to assign a status of "completed"
+3. Commit the status update to VCS
+4. Call the `ralph-pr` skill using the Skill tool with the same arguments that were passed to this skill
+
+## Notes
+
+- The refactor phase is about improving code quality without changing behavior - all tests should remain passing throughout
+- Security is not optional - every task must pass security review before completion
+- When in doubt about a security concern, err on the side of caution and fix it

--- a/.claude/skills/ralph-test/SKILL.md
+++ b/.claude/skills/ralph-test/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: ralph-test
+description: Use this skill when writing tests, especially when working in TDD style to define tests before the actual functions are complete. This is the "Red" phase of TDD.
+---
+
+Your goal is to write tests for the currently scoped task. You should be able to do this autonomously with no input from the user, if you need more information look at the SCOPES.yml or DESIGN.yml files for the project.
+
+## Tasks That Don't Require Tests
+
+Some tasks have no testable behavior. Before writing tests, evaluate if the task falls into one of these categories:
+
+- **TypeScript type definitions** - Interfaces, type aliases, enums, and other pure type constructs have no runtime behavior to test. The TypeScript compiler validates these.
+- **Type-only files** - Files that only export types (e.g., `webhookTypes.ts`, `*Types.ts`) don't need tests.
+- **Re-exports** - Files that simply re-export from other modules.
+
+If the task only involves creating types/interfaces with no runtime code:
+1. Skip directly to the ralph-code skill (no stubs or tests needed)
+2. Pass the same arguments that were passed to this skill
+
+Otherwise, proceed with the normal test-writing workflow below.
+
+---
+
+First, create stubs:
+In the code being tested create stubs for any missing functions for the task we're devleoping. These functions can have hard coded or empty return values and should not cause any side effects.  This will give us something for the tests to import and run, expecting that the tests themselves will initially be failing.
+
+Second, create tests:
+- Tests should be organized by behaviors, using nested describe blocks if needed
+- **DO** write tests for exported/public functions
+- **DO** write tests for reasonable edge cases but these should be limited
+- **DO NOT** over test, make sure intended behaviors and happy paths are tested but do not write tests for things that should not happen
+- **DO NOT** write tests for private functions or internal implementation details
+- Don't over-mock, try to use the real versions of methods when doing so doesn't add a lot of additional effort or make the tests hard to reason about
+- Keep tests focused on just one or two assertions. If a test has more than 3 assertions it may need to be broken up into multiple tests. This is not a rule but a strong guideline.
+- Don't write lots of test utility functions, limit these to things like object generators, but in general having a lot of code in tests causes confusing and brittle tests, prefer to hard code the values you need when this would not significantly bloat the test
+- Don't test implementation details - directly or indirectly - of third party modules or systems, trust those development teams to have done their jobs and only test the systems we're responsible for
+
+Third, reevaluate the quality of each test - delete or update any that do not pass these criteria
+- Is the test accurate
+- Does the test describe a behavior that needs to be protected and/or documented, or is it just an implementation detail
+- Is the test simple and readable
+- Is this test redundant
+- **IMPORTANT** Is this test testing code, or just testing itself. It is easy to accidentally write tests that, because of mocking and contrived data, do not test the function in any meaningful way and instead just confirm that they return what they've already forced the code to return
+
+Fourth, update the current task in the SCOPES.yml file to assign a status of "testing"
+
+Fifth, commit ALL changes (including the status update) to VCS.
+
+Finally, call the ralph-code skill using the Skill tool with the same arguments that were passed to this skill.

--- a/.claude/skills/scope/SKILL.md
+++ b/.claude/skills/scope/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: scope
+description: Use this to turn a design into a set of small, atomic, achievable tasks that are ready for execution
+---
+
+Your goal is to take a design or plan file and to scope a list of tasks that a team of agents or developers can follow to implement the design.
+
+You should be provided with the path to a design or plan file. If you're not sure where the design is you may ask the user.
+
+**CRITICAL** DO NOT modify any code or attempt to make changes during the scoping process.
+
+## Required Information
+
+Before starting, ask the user for:
+1. **GitHub repository** - The repo where issues will be created (e.g., `owner/repo`). Ask: "What is the GitHub repository for this work?"
+
+## Process
+
+At the end of scoping you should:
+1. Create GitHub milestones for each logical grouping (typically per PR)
+2. Create GitHub issues for each task, assigned to the appropriate milestone
+3. Create (or update) a ./designs/solution-name/SCOPES.yml file with the outcome of the scoping process
+
+DO look up referenced GitHub issues and repos, find and read relevant files in the current project and use the WebSearch tool to check your work and update your understanding
+
+Read the design file, it should be complete and answer most questions. Identify task boundaries for implementing the design. For some designs it may be only one task, often a design will require multiple tasks. Remember that the design file may be categorized topically not by task, your job is to find the commonalities and dependencies in the design and identify units of work.
+
+A task should be atomic, complete and achievable. A developer or agent should be able to pick up an individual task and carry it to completion quickly and without requiring external feedback.
+
+- **Atomic**: A task focuses on a single, indivisible unit of work that cannot be meaningfully broken down further. It has one clear purpose and produces one discrete outcome. If a task requires multiple distinct changes across unrelated parts of the system, it should be split into separate tasks.
+
+- **Complete**: A task is self-contained with all necessary context, requirements, and acceptance criteria included. The task description should provide enough information that someone unfamiliar with the broader project can understand what needs to be done and why. All dependencies on other tasks should be explicitly identified.
+
+- **Achievable**: A task can be completed in a reasonable timeframe (typically a few hours) with the available tools, knowledge, and resources. It should not require major architectural decisions, extensive research, or waiting on external factors. The scope is small enough that a developer can hold the entire context in their head while implementing it.
+
+## Testing Approach
+
+All tasks are developed using **Test-Driven Development (TDD)**. Do NOT create separate tasks for writing unit tests. Tests are written as part of each implementation task. Only create separate testing tasks for integration tests that span multiple components or require special setup (e.g., in-memory database, external API mocking across the full system).
+
+## Branching and PR Strategy
+
+Once you've identified all the tasks you also need to decide how to best divide the project into branches or PRs.
+
+**Branch naming**: All branches must be prefixed with the GitHub issue number (e.g., `123-feature-name`).
+
+**PR boundaries**: Consider separating work into logical PR boundaries:
+- **Additive PRs first**: New code (types, classes, modules) that doesn't change existing behavior can be merged independently and reviewed in isolation.
+- **Integration PRs second**: Wiring up new code to existing handlers/entry points should be a separate PR. This makes rollback easier and review clearer.
+- **Small unrelated changes**: If there are multiple small unrelated changes that all carry low risk of issues or regression then these can be combined into one branch. If all tasks for the project meet this criteria there may be only one branch for the whole project.
+
+**PR dependencies**: Never assume a previous PR has been merged when planning subsequent work. If a task depends on work from a previous PR:
+- The previous PR's branch **must** be set as the `base` branch for the dependent task, OR
+- The tasks should be combined into a single PR if the complexity allows
+
+This ensures developers can work on dependent tasks immediately without waiting for PR reviews/merges.
+
+**Remember** PRs should also be reasonably sized and focused so strike a balance between giving every task its own branch vs putting the whole scope of work in a single PR.
+
+## GitHub Milestone & Issue Creation
+
+### Creating Milestones
+
+Group related tasks into milestones (typically one milestone per PR). Use the GitHub API to create milestones:
+
+```bash
+gh api repos/{owner}/{repo}/milestones -f title="1. Milestone Name" -f description="Description of this milestone" -f state="open"
+```
+
+### Creating Issues
+
+For each task, create a GitHub issue assigned to its milestone:
+
+```bash
+gh issue create --repo {owner}/{repo} \
+  --title "Task title" \
+  --body "Task description with acceptance criteria" \
+  --milestone "1. Milestone Name" \
+  --label "enhancement"
+```
+
+The issue body should include:
+- **Description**: What needs to be done
+- **Acceptance Criteria**: Checklist of requirements
+- **Dependencies**: Links to blocking issues (if any)
+
+### Workflow
+
+1. First, create all milestones
+2. Then, create issues for each task, assigning them to the appropriate milestone
+3. Record the issue numbers in SCOPES.yml
+
+## SCOPES.yml Format
+
+When you've identified all the tasks, created the GitHub milestones/issues, and determined the branching strategy, create a SCOPES.yml file:
+
+```yaml
+project: project name
+repo: owner/repo
+design_file: path/to/DESIGN.md
+scoping_date: 2026-01-01
+
+milestones:
+  - number: 1
+    title: "1. Milestone Name"
+    description: What this milestone accomplishes
+    branch:
+      working: milestone-branch-name
+      base: main
+
+tasks:
+  - id: 1
+    github_issue: 123  # The GitHub issue number created for this task
+    milestone: 1  # References milestones[].number
+    title: one sentence description of the task
+    description: |
+      Task description with all necessary details in MD format
+    acceptance_criteria: # at least one, can be more
+      - behaviors and must-have implementation details
+    depends_on: []  # list of task ids, may be empty
+    effort: 1  # 1 = low, 5 = high
+    status: scoped  # MUST be exactly "scoped" at this point
+```
+
+If a task has an effort over 3 or an acceptance criteria with more than 4 items in it confirm that it is truly atomic. It may be possible to break it down further unless doing so would impact its completeness.
+
+When defining tasks it is not necessary to provide implementation details or code samples but you may choose to do so if it makes the description easier to understand.

--- a/designs/legibility-refactor/DESIGN.md
+++ b/designs/legibility-refactor/DESIGN.md
@@ -1,0 +1,176 @@
+# Legibility Refactor Design
+
+## Overview
+
+This refactoring project aims to improve the gcode2dplotterart library's:
+- **IntelliSense/IDE support** - Better type hints that display clearly in editors
+- **Code legibility** - Reduce repetition and improve maintainability
+- **Documentation generation** - Replace the brittle `docstrings2md.py` with proper tooling
+
+## Current Problems
+
+### 1. Poor IntelliSense Support
+
+**Type aliases don't display well:**
+```python
+# Current - shows as Union[Literal['Warning'], Literal['Error']] in IDE
+THandleOutOfBounds = Union[Literal["Warning"], Literal["Error"]]
+
+# Better - shows as "Warning" | "Error" in modern IDEs
+HandleOutOfBounds = Literal["Warning", "Error"]
+```
+
+**Instruction classes lack a common interface:**
+- `InstructionFeedRate` doesn't inherit from `_BaseInstruction`
+- `Instruction3DPrinterPlottingHeight` doesn't inherit from `_BaseInstruction`
+- This breaks type inference and IDE autocomplete
+
+**Class attributes declared without types in some places:**
+- `_AbstractPlotter` declares attributes at class level but also in `__init__`
+- Inconsistent patterns confuse type checkers
+
+### 2. Repetitive Code
+
+**Plotter2D vs Plotter3D:**
+- 90% identical code
+- Only difference: Plotter3D has `z_plotting_height` and `z_navigation_height`
+- Could use generics or a factory pattern
+
+**Layer2D vs Layer3D:**
+- 95% identical code
+- Only difference: `set_mode_to_plotting()` and `set_mode_to_navigation()` implementations
+- Abstract base already exists but subclasses still have repetitive `__init__` docstrings
+
+**Long parameter lists:**
+- `_AbstractLayer.__init__` takes 10 parameters
+- These get repeated in docstrings for Layer2D and Layer3D
+- Could use dataclasses or parameter objects
+
+### 3. Brittle Documentation Generation
+
+**docstrings2md.py issues:**
+- Hardcoded string manipulation (`signature.split("->")`)
+- Produces ugly output with `Union[Literal['x'], Literal['y']]`
+- Line wrapping issues in generated markdown
+- No support for nested types or complex signatures
+
+**Better alternatives:**
+- Use Sphinx with autodoc for proper API documentation
+- Or use mkdocs with mkdocstrings
+- Both handle type annotations properly and produce clean output
+
+## Proposed Changes
+
+### Phase 1: Fix Type Hints for Better IntelliSense
+
+1. **Simplify type aliases** in `shared_types.py`:
+   ```python
+   # Use simple Literal syntax
+   HandleOutOfBounds = Literal["Warning", "Error"]
+   InstructionPhase = Literal["setup", "plotting", "teardown"]
+   ```
+
+2. **Create proper Instruction protocol/base class:**
+   ```python
+   class Instruction(Protocol):
+       def to_g_code(self) -> str: ...
+       def __str__(self) -> str: ...
+   ```
+
+3. **Ensure all instruction classes implement the protocol**
+
+4. **Use TypedDict for bounds dictionaries:**
+   ```python
+   class Bounds(TypedDict):
+       x_min: float
+       x_max: float
+       y_min: float
+       y_max: float
+   ```
+
+### Phase 2: Reduce Repetition with Dataclasses
+
+1. **Create a PlotterConfig dataclass:**
+   ```python
+   @dataclass
+   class PlotterConfig:
+       title: str
+       x_min: float
+       x_max: float
+       y_min: float
+       y_max: float
+       feed_rate: float
+       handle_out_of_bounds: HandleOutOfBounds = "Warning"
+       output_directory: str = "./output"
+       include_comments: bool = True
+       return_home_before_plotting: bool = True
+   ```
+
+2. **Create a LayerConfig dataclass** to reduce `__init__` parameter sprawl
+
+3. **Simplify Plotter2D/Plotter3D** to only contain their specific logic
+
+### Phase 3: Replace docstrings2md.py
+
+1. **Delete docstrings2md.py**
+
+2. **Add Sphinx with autodoc** or **mkdocs with mkdocstrings**:
+   - Properly handles type annotations
+   - Generates clean, navigable API docs
+   - Integrates with Docusaurus or replaces it
+
+3. **Update docstrings to use standard format** (Google or NumPy style consistently)
+
+### Phase 4: Consolidate Instruction Classes
+
+1. **Merge SimpleInstruction.py and InstructionWithArguments.py** into a single `instructions.py`
+
+2. **Use a single base class pattern:**
+   ```python
+   @dataclass
+   class Instruction(ABC):
+       @abstractmethod
+       def to_g_code(self) -> str: ...
+
+   @dataclass
+   class PointInstruction(Instruction):
+       x: float
+       y: float
+       feed_rate: float
+
+       def to_g_code(self) -> str:
+           return f"G1 X{self.x:.3f} Y{self.y:.3f} F{self.feed_rate}"
+   ```
+
+3. **Remove redundant `__str__` methods** where they just duplicate `to_g_code`
+
+## File Changes Summary
+
+| File | Action |
+|------|--------|
+| `shared_types.py` | Refactor type aliases, add TypedDict |
+| `instruction/SimpleInstruction.py` | Merge into `instructions.py` |
+| `instruction/InstructionWithArguments.py` | Merge into `instructions.py` |
+| `instruction/__init__.py` | Update exports |
+| `_Plotter.py` | Use PlotterConfig dataclass |
+| `Plotter2D.py` | Simplify using config |
+| `Plotter3D.py` | Simplify using config |
+| `layer/_Layer.py` | Use LayerConfig dataclass |
+| `layer/Layer2D.py` | Simplify using config |
+| `layer/Layer3D.py` | Simplify using config |
+| `docstrings2md.py` | DELETE |
+| `pyproject.toml` | Add sphinx/mkdocs dependencies |
+| New: `docs/` | Sphinx/mkdocs configuration |
+
+## Testing Strategy
+
+- All existing snapshot tests must pass
+- Run mypy to verify type improvements
+- Manual verification of IntelliSense in VS Code/PyCharm
+- Verify generated documentation renders correctly
+
+## Migration Notes
+
+- Public API remains unchanged (Plotter2D, Plotter3D, Layer2D, Layer3D)
+- Internal restructuring is transparent to users
+- No breaking changes to existing code using the library

--- a/designs/legibility-refactor/SCOPES.yml
+++ b/designs/legibility-refactor/SCOPES.yml
@@ -9,7 +9,7 @@ milestones:
     description: Simplify type aliases and ensure all instruction classes have proper interfaces for better IDE support
     branch:
       working: 57-fix-type-hints
-      base: main
+      base: claude-rewrite
 
   - number: 2
     title: "2. Reduce Repetition with Dataclasses"

--- a/designs/legibility-refactor/SCOPES.yml
+++ b/designs/legibility-refactor/SCOPES.yml
@@ -50,7 +50,7 @@ tasks:
       - mypy passes with no new errors
     depends_on: []
     effort: 2
-    status: implementing
+    status: completed
 
   - id: 2
     github_issue: 58

--- a/designs/legibility-refactor/SCOPES.yml
+++ b/designs/legibility-refactor/SCOPES.yml
@@ -1,0 +1,185 @@
+project: Legibility Refactor
+repo: travisbumgarner/gcode2dplotterart
+design_file: designs/legibility-refactor/DESIGN.md
+scoping_date: 2026-01-17
+
+milestones:
+  - number: 1
+    title: "1. Fix Type Hints for Better IntelliSense"
+    description: Simplify type aliases and ensure all instruction classes have proper interfaces for better IDE support
+    branch:
+      working: 57-fix-type-hints
+      base: main
+
+  - number: 2
+    title: "2. Reduce Repetition with Dataclasses"
+    description: Introduce PlotterConfig and LayerConfig dataclasses to reduce parameter sprawl and duplicated docstrings
+    branch:
+      working: 59-reduce-repetition-dataclasses
+      base: 57-fix-type-hints
+
+  - number: 3
+    title: "3. Consolidate Instruction Classes"
+    description: Merge instruction files and use dataclasses for cleaner instruction definitions
+    branch:
+      working: 61-consolidate-instructions
+      base: 59-reduce-repetition-dataclasses
+
+  - number: 4
+    title: "4. Replace Documentation Generation"
+    description: Delete docstrings2md.py and implement proper documentation tooling
+    branch:
+      working: 63-replace-docs
+      base: 61-consolidate-instructions
+
+tasks:
+  - id: 1
+    github_issue: 57
+    milestone: 1
+    title: Simplify type aliases in shared_types.py
+    description: |
+      Refactor type aliases to use simpler `Literal["a", "b"]` syntax instead of
+      `Union[Literal["a"], Literal["b"]]`. Remove the `T` prefix from type names.
+      Add a `Bounds` TypedDict for structured return types.
+    acceptance_criteria:
+      - Type aliases use Literal["a", "b"] syntax
+      - Remove T prefix from type names (HandleOutOfBounds not THandleOutOfBounds)
+      - Add Bounds TypedDict for min/max point dictionaries
+      - Update all imports throughout codebase
+      - All existing tests pass
+      - mypy passes with no new errors
+    depends_on: []
+    effort: 2
+    status: implementing
+
+  - id: 2
+    github_issue: 58
+    milestone: 1
+    title: Create unified Instruction protocol and fix inheritance
+    description: |
+      Create an `Instruction` Protocol that all instruction classes implement.
+      Fix classes that don't inherit from a base class: InstructionFeedRate,
+      Instruction3DPrinterPlottingHeight, Instruction3DPrinterNavigationHeight.
+    acceptance_criteria:
+      - Create Instruction protocol in instruction module
+      - All instruction classes implement the protocol
+      - Update TInstructionUnion type in _Layer.py to use the protocol
+      - All existing tests pass
+      - mypy passes with no new errors
+    depends_on: []
+    effort: 2
+    status: scoped
+
+  - id: 3
+    github_issue: 59
+    milestone: 2
+    title: Create PlotterConfig dataclass to reduce parameter sprawl
+    description: |
+      Create a PlotterConfig dataclass to group the 10 parameters currently passed
+      to _AbstractPlotter.__init__. Maintain backwards-compatible constructors.
+    acceptance_criteria:
+      - Create PlotterConfig dataclass in new config.py file
+      - Update _AbstractPlotter to use config internally
+      - Plotter2D and Plotter3D maintain backwards-compatible constructors
+      - Export PlotterConfig from package __init__.py
+      - All existing tests pass
+    depends_on: [1]
+    effort: 3
+    status: scoped
+
+  - id: 4
+    github_issue: 60
+    milestone: 2
+    title: Create LayerConfig dataclass to reduce layer parameter sprawl
+    description: |
+      Create a LayerConfig dataclass to group layer parameters. Similar pattern
+      to PlotterConfig.
+    acceptance_criteria:
+      - Create LayerConfig dataclass in config.py
+      - Update _AbstractLayer to use config internally
+      - Layer2D and Layer3D use simplified constructors
+      - All existing tests pass
+    depends_on: [1, 3]
+    effort: 2
+    status: scoped
+
+  - id: 5
+    github_issue: 61
+    milestone: 3
+    title: Consolidate instruction classes into single module
+    description: |
+      Merge SimpleInstruction.py and InstructionWithArguments.py into a single
+      instructions.py file. Use consistent base class pattern.
+    acceptance_criteria:
+      - Create new instruction/instructions.py with all instruction classes
+      - Use consistent base class pattern for all instructions
+      - Delete SimpleInstruction.py and InstructionWithArguments.py
+      - Update instruction/__init__.py exports
+      - All imports throughout codebase updated
+      - All existing tests pass
+    depends_on: [2]
+    effort: 2
+    status: scoped
+
+  - id: 6
+    github_issue: 62
+    milestone: 3
+    title: Convert instruction classes to dataclasses
+    description: |
+      Convert all instruction classes to dataclasses for cleaner definitions.
+      Move validation to __post_init__ where applicable.
+    acceptance_criteria:
+      - All instruction classes converted to dataclasses
+      - Remove redundant __str__ methods where not needed
+      - Validation moved to __post_init__ where applicable
+      - All existing tests pass
+      - mypy passes
+    depends_on: [5]
+    effort: 2
+    status: scoped
+
+  - id: 7
+    github_issue: 63
+    milestone: 4
+    title: Delete docstrings2md.py
+    description: |
+      Delete the brittle docstrings2md.py script from the repository root.
+    acceptance_criteria:
+      - Delete docstrings2md.py from repository root
+      - Remove any references to the script
+    depends_on: []
+    effort: 1
+    status: scoped
+
+  - id: 8
+    github_issue: 64
+    milestone: 4
+    title: Set up mkdocs with mkdocstrings for API documentation
+    description: |
+      Replace custom documentation generation with mkdocs and mkdocstrings.
+      Configure to generate API docs from Python docstrings.
+    acceptance_criteria:
+      - Add mkdocs and mkdocstrings to dev dependencies
+      - Create mkdocs.yml configuration file
+      - Configure mkdocstrings for Python API docs
+      - Generate API documentation for main classes
+      - Document how to regenerate docs
+    depends_on: [7]
+    effort: 3
+    status: scoped
+
+  - id: 9
+    github_issue: 65
+    milestone: 4
+    title: Standardize docstrings to Google style
+    description: |
+      Standardize all docstrings to Google style format for consistency
+      and better mkdocstrings parsing.
+    acceptance_criteria:
+      - All public methods use Google-style docstrings
+      - Remove redundant type info from docstrings (types are in annotations)
+      - Consistent formatting across all modules
+      - mkdocstrings renders all docstrings correctly
+    depends_on: [5, 6, 8]
+    effort: 3
+    status: scoped

--- a/gcode2dplotterart/Plotter2D.py
+++ b/gcode2dplotterart/Plotter2D.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from ._Plotter import _AbstractPlotter
 from .layer import Layer2D
-from .shared_types import THandleOutOfBounds
+from .shared_types import HandleOutOfBounds
 
 
 class Plotter2D(_AbstractPlotter):
@@ -20,7 +20,7 @@ class Plotter2D(_AbstractPlotter):
         y_min: float,
         y_max: float,
         feed_rate: float,
-        handle_out_of_bounds: THandleOutOfBounds = "Warning",
+        handle_out_of_bounds: HandleOutOfBounds = "Warning",
         output_directory: str = "./output",
         include_comments: bool = True,
         return_home_before_plotting: bool = True,

--- a/gcode2dplotterart/Plotter3D.py
+++ b/gcode2dplotterart/Plotter3D.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from ._Plotter import _AbstractPlotter
 from .layer import Layer3D
-from .shared_types import THandleOutOfBounds
+from .shared_types import HandleOutOfBounds
 
 
 class Plotter3D(_AbstractPlotter):
@@ -25,7 +25,7 @@ class Plotter3D(_AbstractPlotter):
         z_plotting_height: float,
         z_navigation_height: float,
         feed_rate: float,
-        handle_out_of_bounds: THandleOutOfBounds = "Warning",
+        handle_out_of_bounds: HandleOutOfBounds = "Warning",
         output_directory: str = "./output",
         include_comments: bool = True,
         return_home_before_plotting: bool = True,

--- a/gcode2dplotterart/_Plotter.py
+++ b/gcode2dplotterart/_Plotter.py
@@ -1,11 +1,11 @@
 import os
 import shutil
-from typing import List, Dict, Union, Optional, Literal
+from typing import List, Dict, Union, Optional
 from abc import ABC, abstractmethod
 import matplotlib.pyplot as plt
 
 from .layer import Layer2D, Layer3D
-from .shared_types import THandleOutOfBounds
+from .shared_types import HandleOutOfBounds, Bounds
 
 
 class _AbstractPlotter(ABC):
@@ -17,7 +17,7 @@ class _AbstractPlotter(ABC):
     feed_rate: float
     layers: Dict[str, Union[Layer2D, Layer3D]]
     output_directory: str
-    handle_out_of_bounds: THandleOutOfBounds
+    handle_out_of_bounds: HandleOutOfBounds
     include_comments: bool
 
     def __init__(
@@ -28,7 +28,7 @@ class _AbstractPlotter(ABC):
         y_min: float,
         y_max: float,
         feed_rate: float,
-        handle_out_of_bounds: THandleOutOfBounds,
+        handle_out_of_bounds: HandleOutOfBounds,
         output_directory: str,
         include_comments: bool,
         return_home_before_plotting: bool,
@@ -47,7 +47,7 @@ class _AbstractPlotter(ABC):
 
     def get_min_and_max_points(
         self,
-    ) -> Dict[Literal["x_min", "y_min", "x_max", "y_max"], float]:
+    ) -> Bounds:
         """
         Find the min and max plot points of the plotter.
 

--- a/gcode2dplotterart/layer/Layer2D.py
+++ b/gcode2dplotterart/layer/Layer2D.py
@@ -2,7 +2,7 @@ from typing import Optional
 from typing_extensions import Self
 
 from ._Layer import _AbstractLayer
-from ..shared_types import THandleOutOfBounds, TInstructionPhase
+from ..shared_types import HandleOutOfBounds, InstructionPhase
 from ..instruction import (
     InstructionPause,
     Instruction2DPlotterNavigationHeight,
@@ -24,7 +24,7 @@ class Layer2D(_AbstractLayer):
         plotter_x_max: float,
         plotter_y_max: float,
         feed_rate: float,
-        handle_out_of_bounds: THandleOutOfBounds,
+        handle_out_of_bounds: HandleOutOfBounds,
         color: Optional[str],
         line_width: float,
         include_comments: bool,
@@ -65,7 +65,7 @@ class Layer2D(_AbstractLayer):
 
     def set_mode_to_plotting(
         self,
-        instruction_phase: TInstructionPhase = "plotting",
+        instruction_phase: InstructionPhase = "plotting",
     ) -> Self:
         self._add_instruction(Instruction2DPlotterPlottingHeight(), instruction_phase)
         self._add_instruction(InstructionPause(), instruction_phase)
@@ -74,7 +74,7 @@ class Layer2D(_AbstractLayer):
 
     def set_mode_to_navigation(
         self,
-        instruction_phase: TInstructionPhase = "plotting",
+        instruction_phase: InstructionPhase = "plotting",
     ) -> Self:
         self._add_instruction(Instruction2DPlotterNavigationHeight(), instruction_phase)
         self._add_instruction(InstructionPause(), instruction_phase)

--- a/gcode2dplotterart/layer/Layer3D.py
+++ b/gcode2dplotterart/layer/Layer3D.py
@@ -2,7 +2,7 @@ from typing import Optional
 from typing_extensions import Self
 
 from ._Layer import _AbstractLayer
-from ..shared_types import THandleOutOfBounds, TInstructionPhase
+from ..shared_types import HandleOutOfBounds, InstructionPhase
 from ..instruction import (
     Instruction3DPrinterNavigationHeight,
     Instruction3DPrinterPlottingHeight,
@@ -28,7 +28,7 @@ class Layer3D(_AbstractLayer):
         z_plotting_height: float,
         z_navigation_height: float,
         feed_rate: float,
-        handle_out_of_bounds: THandleOutOfBounds,
+        handle_out_of_bounds: HandleOutOfBounds,
         color: Optional[str],
         line_width: float,
         include_comments: bool,
@@ -78,7 +78,7 @@ class Layer3D(_AbstractLayer):
 
     def set_mode_to_plotting(
         self,
-        instruction_phase: TInstructionPhase = "plotting",
+        instruction_phase: InstructionPhase = "plotting",
     ) -> Self:
         self._add_instruction(
             Instruction3DPrinterPlottingHeight(
@@ -93,7 +93,7 @@ class Layer3D(_AbstractLayer):
 
     def set_mode_to_navigation(
         self,
-        instruction_phase: TInstructionPhase = "plotting",
+        instruction_phase: InstructionPhase = "plotting",
     ) -> Self:
         self._add_instruction(
             Instruction3DPrinterNavigationHeight(

--- a/gcode2dplotterart/layer/_Layer.py
+++ b/gcode2dplotterart/layer/_Layer.py
@@ -4,7 +4,7 @@ import math
 from abc import ABC, abstractmethod
 import secrets
 
-from ..shared_types import THandleOutOfBounds, TInstructionPhase
+from ..shared_types import HandleOutOfBounds, InstructionPhase, Bounds
 from ..instruction import (
     InstructionPoint,
     Instruction3DPrinterPlottingHeight,
@@ -51,7 +51,7 @@ TInstructionUnion = Union[
 
 
 class _AbstractLayer(ABC):
-    instructions: Dict[TInstructionPhase, List[TInstructionUnion]]
+    instructions: Dict[InstructionPhase, List[TInstructionUnion]]
 
     def __init__(
         self,
@@ -60,7 +60,7 @@ class _AbstractLayer(ABC):
         plotter_x_max: float,
         plotter_y_max: float,
         feed_rate: float,
-        handle_out_of_bounds: THandleOutOfBounds,
+        handle_out_of_bounds: HandleOutOfBounds,
         color: Optional[str],
         line_width: float,
         include_comments: bool,
@@ -68,7 +68,7 @@ class _AbstractLayer(ABC):
     ):
         self.color = color if color else f"#{secrets.token_hex(3, )}"
 
-        self.instructions: Dict[TInstructionPhase, TInstructionUnion] = {
+        self.instructions: Dict[InstructionPhase, TInstructionUnion] = {
             "setup": [],
             "plotting": [],
             "teardown": [],
@@ -122,7 +122,7 @@ class _AbstractLayer(ABC):
         if y > self.layer_y_max:
             self.layer_y_max = y
 
-    def get_min_and_max_points(self) -> Dict[str, float]:
+    def get_min_and_max_points(self) -> Bounds:
         """
         Find the min and max plot points of the layer.
 
@@ -141,7 +141,7 @@ class _AbstractLayer(ABC):
     def set_feed_rate(
         self,
         feed_rate: float,
-        instruction_phase: TInstructionPhase = "plotting",
+        instruction_phase: InstructionPhase = "plotting",
     ) -> Self:
         """
         Set the speed at which the [plotter head](https://travisbumgarner.github.io/gcode2dplotterart/docs/documentation/terminology#plotting-instrument)
@@ -163,7 +163,7 @@ class _AbstractLayer(ABC):
     @abstractmethod
     def set_mode_to_plotting(
         self,
-        instruction_phase: TInstructionPhase = "plotting",
+        instruction_phase: InstructionPhase = "plotting",
     ) -> Self:
         """
         Connect [plotting instrument](https://travisbumgarner.github.io/gcode2dplotterart/docs/documentation/terminology#plotting-instrument)
@@ -183,7 +183,7 @@ class _AbstractLayer(ABC):
     @abstractmethod
     def set_mode_to_navigation(
         self,
-        instruction_phase: TInstructionPhase = "plotting",
+        instruction_phase: InstructionPhase = "plotting",
     ) -> Self:
         """
         Separate [plotting instrument](https://travisbumgarner.github.io/gcode2dplotterart/docs/documentation/terminology#plotting-instrument)
@@ -201,7 +201,7 @@ class _AbstractLayer(ABC):
 
         pass
 
-    def _add_home(self, instruction_phase: TInstructionPhase = "plotting") -> Self:
+    def _add_home(self, instruction_phase: InstructionPhase = "plotting") -> Self:
         """
         Add a home instruction to the layer.
         """
@@ -209,7 +209,7 @@ class _AbstractLayer(ABC):
         return self
 
     def _add_coordinate(
-        self, x: float, y: float, instruction_phase: TInstructionPhase
+        self, x: float, y: float, instruction_phase: InstructionPhase
     ) -> Self:
         """
         Add a coordinate to the layer. Typically not used directly, instead use one of the other add methods.
@@ -221,7 +221,7 @@ class _AbstractLayer(ABC):
         return self
 
     def _add_instruction(
-        self, instruction: TInstructionUnion, instruction_phase: TInstructionPhase
+        self, instruction: TInstructionUnion, instruction_phase: InstructionPhase
     ) -> Self:
         if not isinstance(instruction, InstructionComment) and self.include_comments:
             self.instructions[instruction_phase].append(
@@ -230,7 +230,7 @@ class _AbstractLayer(ABC):
         self.instructions[instruction_phase].append(instruction)
         return self
 
-    def add_comment(self, text: str, instruction_phase: TInstructionPhase) -> Self:
+    def add_comment(self, text: str, instruction_phase: InstructionPhase) -> Self:
         """Add a comment to the layer.
 
         Args:
@@ -253,7 +253,7 @@ class _AbstractLayer(ABC):
         self,
         points: List[Tuple[float, float]],
         raise_plotter_head_after_path: bool = True,
-        instruction_phase: TInstructionPhase = "plotting",
+        instruction_phase: InstructionPhase = "plotting",
     ) -> Self:
         """
         Add a path to the layer. A path is a series of points that are connected by lines.
@@ -305,7 +305,7 @@ class _AbstractLayer(ABC):
         x: float,
         y: float,
         raise_plotter_head_after_path: bool = True,
-        instruction_phase: TInstructionPhase = "plotting",
+        instruction_phase: InstructionPhase = "plotting",
     ) -> Self:
         """
         Add a point to the layer. `add_point` calls `add_path` under the hood, for more control, use `add_path` directly.
@@ -338,7 +338,7 @@ class _AbstractLayer(ABC):
         x_end: float,
         y_end: float,
         raise_plotter_head_after_path: bool = True,
-        instruction_phase: TInstructionPhase = "plotting",
+        instruction_phase: InstructionPhase = "plotting",
     ) -> Self:
         """
         Add a line to the layer. `add_line` calls `add_path` under the hood, for more control, use `add_path` directly.
@@ -373,7 +373,7 @@ class _AbstractLayer(ABC):
         x_end: float,
         y_end: float,
         raise_plotter_head_after_path: bool = True,
-        instruction_phase: TInstructionPhase = "plotting",
+        instruction_phase: InstructionPhase = "plotting",
     ) -> Self:
         """
         Adds a rectangle to the layer.  `add_rectangle` calls `add_path` under the hood, for more control, use `add_path` directly.
@@ -416,7 +416,7 @@ class _AbstractLayer(ABC):
         radius: float,
         num_points: int = 36,
         raise_plotter_head_after_path: bool = True,
-        instruction_phase: TInstructionPhase = "plotting",
+        instruction_phase: InstructionPhase = "plotting",
     ) -> Self:
         """
         Adds a circle to the layer. `add_circle` calls `add_path` under the hood, for more control, use `add_path` directly.
@@ -466,7 +466,7 @@ class _AbstractLayer(ABC):
         y_start: float,
         char_spacing: Optional[float] = None,
         point_offset: Optional[float] = None,
-        instruction_phase: TInstructionPhase = "plotting",
+        instruction_phase: InstructionPhase = "plotting",
     ) -> Self:
         """
         Adds a text to the layer. `add_text` calls `add_path` under the hood, for more control, use `add_path` directly.

--- a/gcode2dplotterart/shared_types.py
+++ b/gcode2dplotterart/shared_types.py
@@ -1,4 +1,12 @@
-from typing import Union, Literal
+from typing import Literal
+from typing_extensions import TypedDict
 
-THandleOutOfBounds = Union[Literal["Warning"], Literal["Error"]]
-TInstructionPhase = Union[Literal["setup"], Literal["plotting"], Literal["teardown"]]
+HandleOutOfBounds = Literal["Warning", "Error"]
+InstructionPhase = Literal["setup", "plotting", "teardown"]
+
+
+class Bounds(TypedDict):
+    x_min: float
+    x_max: float
+    y_min: float
+    y_max: float

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 # The Python version for which the type checking is performed.
 # You can specify a specific version or use "python3" for the default Python 3 version.
-python_version = 3.8
+python_version = 3.9
 
 # Check all files in the project.
 files = ./gcode2dplotterart


### PR DESCRIPTION
## Summary

Refactored type aliases in `shared_types.py` to improve IntelliSense/IDE support:

- Changed `Union[Literal["a"], Literal["b"]]` to simpler `Literal["a", "b"]` syntax
- Removed the non-standard `T` prefix from type names
- Added a `Bounds` TypedDict for structured min/max point dictionaries
- Updated `mypy.ini` to use Python 3.9 (3.8 is no longer supported by mypy)

## Acceptance Criteria

- [x] Type aliases use Literal["a", "b"] syntax
- [x] Remove T prefix from type names (HandleOutOfBounds not THandleOutOfBounds)
- [x] Add Bounds TypedDict for min/max point dictionaries
- [x] Update all imports throughout codebase
- [x] All existing tests pass
- [x] mypy passes with no new errors

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)