### PR TITLE
Add paint-app: browser-based 2D plotter control UI

### DIFF
--- a/paint-app/.gitignore
+++ b/paint-app/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+dist-ssr
+*.local
+*.tsbuildinfo
+.vite
+.DS_Store

--- a/paint-app/README.md
+++ b/paint-app/README.md
@@ -1,0 +1,143 @@
+# paint-app
+
+A browser-based paint app that draws on virtual pages with stacked, color-coded
+layers and emits G-code to a USB-connected pen plotter (a Creality Ender-3 V3
+SE running stock Marlin in this repo).
+
+## Stack
+
+- Vite + React + TypeScript
+- Material UI (theme + dialogs + menus)
+- Dexie (IndexedDB) for project persistence
+- Zod for runtime schemas
+- Framer Motion for layer drag-and-drop reordering
+- Biome for lint + format
+- [Web Serial API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API) for plotter I/O — Chrome / Edge only
+
+## Develop
+
+```sh
+npm install
+npm run dev
+```
+
+The dev server runs on `http://localhost:5173`. Web Serial requires a secure
+context, which `localhost` qualifies as.
+
+```sh
+npm run build     # production build
+npm run check     # biome lint + format with --write
+npm run lint      # biome check (no writes)
+```
+
+## Plotters
+
+Plotters are first-class entities, separate from projects. Each plotter has a
+name, bed size, feed rates, and pen Z heights. Plotters are **immutable once
+created** — to change a parameter you must create a new plotter and switch the
+project over to it. This keeps documents reproducible: a project that
+references plotter `X` will always print exactly the way it did when you saved
+it.
+
+- A project picks its plotter at creation time and is bound to it for life.
+  This mirrors the immutability of plotters themselves — the (project, plotter)
+  pair is a fixed contract once you click Create.
+- Plotters are managed from the Settings menu (top-left ⚙ → "Plotters…") or
+  via the "Manage…" button in the home-screen New project form.
+- Deleting a plotter is blocked while any project references it.
+- Two ways to define a new plotter:
+  - **Manual** — type each field (bed size, feeds, pen Z heights).
+  - **Calibrate** — connect the plotter and walk through six steps (left,
+    right, top, bottom, pen-down, pen-up). Each step jogs the head with
+    on-screen arrow buttons and captures the live `M114` position.
+    Bed dimensions are derived from the captured X/Y extremes.
+- Exported JSON bundles a snapshot of the plotter so the document is portable
+  across browsers / machines.
+
+## Interactive mode
+
+Selecting **Interactive session** from the home screen opens the same UI as a
+normal document, with two differences:
+
+- There can only be **one** interactive session, and it is **ephemeral** —
+  closing or reopening "Interactive session" gives you a fresh canvas.
+  Nothing is written to IndexedDB; autosave and the beforeunload guard skip
+  interactive projects entirely.
+- Every stroke you draw is **streamed to the plotter the moment you finish
+  it**. The first stroke after a fresh connection sends the prologue
+  (`G21 / G90 / G28`), and subsequent strokes are queued sequentially over
+  the serial bus.
+
+A red "Interactive · live" chip appears in the AppBar while a session is
+active and connected. If the plotter is disconnected, the chip turns gray
+("offline") and strokes you draw are NOT replayed when you reconnect — only
+strokes drawn while connected get plotted.
+
+## Saving and loading
+
+- **Project gate.** On load, a modal asks you to create a new project or open
+  an existing one. Projects live in IndexedDB (no backend).
+- **Autosave.** Toggleable in the **Settings** menu (top-left ⚙). When on,
+  changes are persisted ~800ms after the last edit.
+- **Save now / status.** The cog tooltip and the AppBar caption show whether
+  the current project is `saved`, `saving…`, `saving soon`, or `unsaved`.
+- **Export / import JSON.** `Settings → Export JSON` downloads
+  `<project>.json`. `Import JSON` validates with Zod and creates a new project.
+- **Beforeunload guard.** Closing the tab while changes are unsaved triggers
+  the browser's "leave this page?" prompt.
+
+## Features
+
+- **Infinite world canvas.** Strokes live in a single shared world-space
+  coordinate system, in mm. Pages are just rectangles laid into that world.
+  Drawing across page boundaries is fine — at print time, each page clips its
+  share of every stroke and translates it into machine coordinates.
+- **Pages.** New pages are added flush against the right edge of the rightmost
+  page (no gap). Click `+` to the right of the rightmost page in the canvas to
+  add another. Click a page to make it active. The active page is highlighted
+  in blue and is what `Print` sends.
+- **Pan / zoom.** Trackpad / scrollbars pan; **Cmd**/**Ctrl** + wheel zooms
+  centered on the cursor. Bottom-right control resets to 100%.
+- **Layers.** Stacked, color-coded, drag-to-reorder (top of the list = top of
+  the stack). Each layer has a color, thickness in mm, and a visibility toggle.
+  Drawing always goes into the active layer.
+- **SVG import.** Toolbar → Import SVG. Paths/polylines/shapes are sampled and
+  inserted as strokes into the active layer, scale-fit to the active page (in
+  world coordinates offset by the page's position).
+- **Freehand drawing.** Click and drag anywhere on a page to paint with the
+  active layer. Drawing is confined to the union of pages — dragging into the
+  gray void commits the current sub-stroke; dragging back onto a page begins
+  a new one without lifting the pointer.
+- **Shape tools.** A vertical palette between the layers panel and canvas
+  offers pen, line, rectangle, ellipse, regular polygon (3–32 sides), and
+  star (3–32 points). Polygon/star spawn a small `sides` / `pts` input under
+  the palette when active; they're built as polylines so they emit clean
+  G-code paths just like freehand strokes.
+- **Plotter output.** Toolbar → Connect, pick the `wchusbserial*` port, then
+  Print. The active page is sent: each visible layer becomes a block of G-code
+  (clipped to the page rectangle and translated to machine origin), with a
+  pause + audio chime + on-screen prompt between layers so you can swap pens.
+
+## Hardware notes
+
+See [`experiments/README.md`](experiments/README.md) for the CH340 driver
+install, the USB hub quirk on this Mac, and the original `jog.py` / `jog.html`
+prototypes that predate this app.
+
+## Layout
+
+```
+src/
+  App.tsx                    # shell + connection wiring
+  store.tsx                  # Context + useReducer app state
+  types.ts                   # Zod schemas / TS types
+  serial.ts                  # Web Serial wrapper (PlotterConnection)
+  gcode.ts                   # stroke -> G-code generator
+  svg-import.ts              # SVG -> sampled strokes
+  clip.ts                    # Liang-Barsky polyline-vs-rect clipping
+  components/
+    Toolbar.tsx
+    LayersPanel.tsx
+    Canvas.tsx
+    PrintModal.tsx
+```

--- a/paint-app/biome.json
+++ b/paint-app/biome.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+  "files": { "ignoreUnknown": false },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": { "recommended": true }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "jsxQuoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "all"
+    }
+  }
+}

--- a/paint-app/deploy.sh
+++ b/paint-app/deploy.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+# paint-app is a pure client-side SPA (Web Serial + IndexedDB, no backend),
+# so deployment is just: build locally, rsync the static dist/ to the
+# NearlyFreeSpeech site's public web root.
+#
+# Requires an SSH alias in ~/.ssh/config:
+#
+#   host nfs_gcode2dplotterart
+#       HostName ssh.nyc1.nearlyfreespeech.net
+#       User tbumgarner_gcode2dplotterart
+#       IdentityFile ~/.ssh/nfs_key
+#
+# Note: Web Serial only works in a secure context — NFS serves the site
+# over HTTPS, so this is fine.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REMOTE="${NFS_REMOTE:-nfs_gcode2dplotterart}"
+REMOTE_DIR="/home/public"
+
+cd "$SCRIPT_DIR"
+
+echo "📦 Installing dependencies..."
+npm install
+
+echo "🎨 Building (tsc + vite)..."
+npm run build
+
+echo "🚀 Syncing dist/ to NearlyFreeSpeech ($REMOTE:$REMOTE_DIR)..."
+rsync -azPh --delete --timeout=300 \
+  dist/ \
+  "$REMOTE:$REMOTE_DIR/"
+
+echo "✅ Deployment complete!"
+echo "🌐 Live at the site's HTTPS URL"

--- a/paint-app/experiments/README.md
+++ b/paint-app/experiments/README.md
@@ -1,0 +1,60 @@
+# experiments
+
+Throwaway prototypes used to figure out how to talk to the plotter
+(a Creality Ender-3 V3 SE) before building the real React app in `../`.
+
+## Files
+
+| file        | what it is                                                            |
+| ----------- | --------------------------------------------------------------------- |
+| `jog.py`    | Python REPL that opens the serial port and accepts jog commands (`up 10`, `home`, raw G-code, etc.). Uses `pyserial`. |
+| `jog.html`  | Same idea in the browser via the Chrome Web Serial API. Single file, no build step — open it directly in Chrome. |
+| `venv/`     | Python virtualenv with `pyserial` for `jog.py`. Recreate with `python3 -m venv venv && source venv/bin/activate && pip install pyserial` if it's stale. |
+
+## macOS prerequisites
+
+### CH340 driver
+
+The printer's USB-to-serial chip is a CH340. macOS doesn't ship with a
+driver. Install from WCH: <https://www.wch-ic.com/downloads/CH34XSER_MAC_ZIP.html>
+After install, approve the driver extension in
+**System Settings → General → Login Items & Extensions → Driver Extensions**.
+
+### USB hub quirk
+
+On this Mac, the printer only enumerates through a USB hub (Anker USB-C).
+Plugging the cable directly into the Mac shows nothing on the USB bus.
+Use the hub.
+
+## jog.py
+
+```sh
+source venv/bin/activate
+python jog.py            # autodetect port
+python jog.py --list     # list available ports
+python jog.py --port /dev/cu.wchusbserial2120
+```
+
+Commands inside the REPL:
+
+| input               | effect                            |
+| ------------------- | --------------------------------- |
+| `up 10`             | Y +10 mm                          |
+| `down 5`            | Y -5 mm                           |
+| `left 2`            | X -2 mm                           |
+| `right 2`           | X +2 mm                           |
+| `z+ 1` / `z- 1`     | Z up / down                       |
+| `home`              | `G28` home all axes               |
+| `pos`               | `M114` print current position     |
+| `feed 6000`         | set jog feed rate (mm/min)        |
+| `raw G1 X10 F3000`  | send any G-code line directly     |
+| `quit` / `q`        | exit                              |
+
+## jog.html
+
+Open in Chrome (or any Chromium browser). Click **Connect**, pick the
+`wchusbserial` port, then use the arrow pad / Z buttons / raw G-code
+input. Same protocol as `jog.py`.
+
+Web Serial requires a secure context. `file://` qualifies in Chrome,
+so double-clicking the file works.

--- a/paint-app/experiments/jog.html
+++ b/paint-app/experiments/jog.html
@@ -1,0 +1,215 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>jog</title>
+<style>
+  :root { font-family: -apple-system, system-ui, sans-serif; }
+  body { margin: 24px; max-width: 640px; }
+  h1 { margin: 0 0 16px; font-size: 20px; }
+  .row { display: flex; gap: 8px; align-items: center; margin-bottom: 12px; flex-wrap: wrap; }
+  button { padding: 10px 14px; font-size: 14px; border: 1px solid #ccc; border-radius: 6px; background: #f7f7f7; cursor: pointer; }
+  button:hover:not(:disabled) { background: #eee; }
+  button:disabled { opacity: 0.5; cursor: not-allowed; }
+  input[type=number], input[type=text] { padding: 8px; font-size: 14px; border: 1px solid #ccc; border-radius: 6px; }
+  .pad { display: grid; grid-template-columns: 60px 60px 60px; grid-template-rows: 60px 60px 60px; gap: 6px; }
+  .pad button { padding: 0; font-size: 18px; }
+  .pad .up    { grid-column: 2; grid-row: 1; }
+  .pad .left  { grid-column: 1; grid-row: 2; }
+  .pad .right { grid-column: 3; grid-row: 2; }
+  .pad .down  { grid-column: 2; grid-row: 3; }
+  .z { display: flex; flex-direction: column; gap: 6px; margin-left: 24px; }
+  .z button { width: 60px; height: 60px; font-size: 16px; }
+  .controls { display: flex; align-items: flex-start; }
+  label { font-size: 13px; color: #444; }
+  #log { width: 100%; height: 240px; font-family: ui-monospace, Menlo, monospace; font-size: 12px; padding: 8px; border: 1px solid #ccc; border-radius: 6px; background: #111; color: #ddd; white-space: pre; overflow: auto; }
+  .status { font-size: 13px; color: #666; }
+  .status.ok { color: #0a7; }
+  .status.err { color: #c33; }
+</style>
+</head>
+<body>
+<h1>jog</h1>
+
+<div class="row">
+  <button id="connect">Connect</button>
+  <button id="disconnect" disabled>Disconnect</button>
+  <span id="status" class="status">disconnected</span>
+</div>
+
+<div class="row">
+  <label>step (mm) <input id="step" type="number" value="10" step="0.1" min="0.1" style="width: 80px"></label>
+  <label>feed (mm/min) <input id="feed" type="number" value="3000" step="100" min="100" style="width: 100px"></label>
+</div>
+
+<div class="controls">
+  <div class="pad">
+    <button class="up"    data-axis="Y" data-sign="1">↑</button>
+    <button class="left"  data-axis="X" data-sign="-1">←</button>
+    <button class="right" data-axis="X" data-sign="1">→</button>
+    <button class="down"  data-axis="Y" data-sign="-1">↓</button>
+  </div>
+  <div class="z">
+    <button data-axis="Z" data-sign="1">Z+</button>
+    <button data-axis="Z" data-sign="-1">Z−</button>
+  </div>
+</div>
+
+<div class="row" style="margin-top: 16px">
+  <button id="home">Home (G28)</button>
+  <button id="pos">Position (M114)</button>
+</div>
+
+<div class="row">
+  <input id="raw" type="text" placeholder="raw G-code, e.g. G1 X10 F3000" style="flex: 1">
+  <button id="send">Send</button>
+</div>
+
+<div id="log"></div>
+
+<script>
+const BAUD = 115200;
+const $ = (id) => document.getElementById(id);
+const logEl = $('log');
+const statusEl = $('status');
+
+let port = null;
+let writer = null;
+let reader = null;
+let readBuffer = '';
+let readResolvers = [];
+
+function log(msg, cls = '') {
+  const line = document.createElement('div');
+  if (cls) line.style.color = cls === 'tx' ? '#7df' : cls === 'rx' ? '#ddd' : cls === 'err' ? '#f88' : '#aaa';
+  line.textContent = msg;
+  logEl.appendChild(line);
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+function setStatus(text, cls = '') {
+  statusEl.textContent = text;
+  statusEl.className = 'status ' + cls;
+}
+
+function setConnected(connected) {
+  $('connect').disabled = connected;
+  $('disconnect').disabled = !connected;
+  document.querySelectorAll('.pad button, .z button, #home, #pos, #send').forEach(b => b.disabled = !connected);
+}
+
+async function connect() {
+  if (!('serial' in navigator)) {
+    log('Web Serial not supported. Use Chrome or Edge.', 'err');
+    return;
+  }
+  try {
+    port = await navigator.serial.requestPort();
+    await port.open({ baudRate: BAUD });
+    setStatus('connected', 'ok');
+    setConnected(true);
+    log(`opened @ ${BAUD}`);
+
+    writer = port.writable.getWriter();
+    startReadLoop();
+
+    // Marlin boards reset on open — wait for boot, then probe.
+    await sleep(2000);
+    await send('M115');
+  } catch (e) {
+    log(`connect failed: ${e.message}`, 'err');
+    setStatus('error', 'err');
+  }
+}
+
+async function disconnect() {
+  try {
+    if (reader) { await reader.cancel(); reader = null; }
+    if (writer) { writer.releaseLock(); writer = null; }
+    if (port) { await port.close(); port = null; }
+  } catch (e) {
+    log(`disconnect: ${e.message}`, 'err');
+  }
+  setStatus('disconnected');
+  setConnected(false);
+  log('closed');
+}
+
+async function startReadLoop() {
+  const decoder = new TextDecoder();
+  reader = port.readable.getReader();
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      readBuffer += decoder.decode(value, { stream: true });
+      let nl;
+      while ((nl = readBuffer.indexOf('\n')) >= 0) {
+        const line = readBuffer.slice(0, nl).replace(/\r$/, '');
+        readBuffer = readBuffer.slice(nl + 1);
+        if (line) {
+          log(line, 'rx');
+          // Notify any waiters; they decide whether this line ends their wait.
+          const resolvers = readResolvers.slice();
+          readResolvers.length = 0;
+          for (const r of resolvers) r(line);
+        }
+      }
+    }
+  } catch (e) {
+    log(`read error: ${e.message}`, 'err');
+  } finally {
+    try { reader.releaseLock(); } catch {}
+  }
+}
+
+function nextLine(timeoutMs) {
+  return new Promise((resolve) => {
+    let done = false;
+    const t = setTimeout(() => { if (!done) { done = true; resolve(null); } }, timeoutMs);
+    readResolvers.push((line) => { if (!done) { done = true; clearTimeout(t); resolve(line); } });
+  });
+}
+
+async function readUntilOk(timeoutMs = 5000) {
+  const end = Date.now() + timeoutMs;
+  while (Date.now() < end) {
+    const line = await nextLine(end - Date.now());
+    if (line === null) break;
+    if (line.toLowerCase().startsWith('ok')) return;
+  }
+}
+
+async function send(gcode) {
+  const line = gcode.trim();
+  if (!line || !writer) return;
+  log(`> ${line}`, 'tx');
+  await writer.write(new TextEncoder().encode(line + '\n'));
+  await readUntilOk();
+}
+
+async function jog(axis, sign) {
+  const step = parseFloat($('step').value);
+  const feed = parseInt($('feed').value, 10);
+  if (!isFinite(step) || !isFinite(feed)) return;
+  await send('G91');
+  await send(`G1 ${axis}${(sign * step).toFixed(3)} F${feed}`);
+  await send('G90');
+}
+
+const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
+$('connect').onclick = connect;
+$('disconnect').onclick = disconnect;
+$('home').onclick = () => send('G28');
+$('pos').onclick = () => send('M114');
+$('send').onclick = () => { const v = $('raw').value; if (v) { send(v); $('raw').value = ''; } };
+$('raw').addEventListener('keydown', (e) => { if (e.key === 'Enter') $('send').click(); });
+document.querySelectorAll('.pad button, .z button').forEach(b => {
+  b.onclick = () => jog(b.dataset.axis, parseInt(b.dataset.sign, 10));
+});
+
+setConnected(false);
+</script>
+</body>
+</html>

--- a/paint-app/experiments/jog.py
+++ b/paint-app/experiments/jog.py
@@ -1,0 +1,186 @@
+"""Interactive jog control for a Creality printer over USB serial.
+
+Type commands like:
+    up 10        move Y +10 mm
+    down 5       move Y -5 mm
+    left 2       move X -2 mm
+    right 2      move X +2 mm
+    z+ 1         move Z +1 mm
+    z- 1         move Z -1 mm
+    home         G28 home all axes
+    pos          query current position (M114)
+    raw G1 X10   send any G-code line directly
+    feed 3000    set feed rate (mm/min) used for jogs
+    quit / q     exit
+"""
+
+import sys
+import time
+import glob
+import argparse
+from typing import Optional
+
+import serial
+from serial.tools import list_ports
+
+
+DEFAULT_BAUD = 115200
+JOG_FEED_DEFAULT = 3000  # mm/min
+
+
+def find_port() -> Optional[str]:
+    """Pick the most likely printer serial port on macOS/Linux."""
+    candidates = []
+    for p in list_ports.comports():
+        dev = p.device
+        # macOS uses /dev/cu.usbserial-*, /dev/cu.usbmodem*, /dev/cu.wchusbserial*
+        if any(s in dev for s in ("usbserial", "usbmodem", "wchusbserial", "SLAB_USBtoUART")):
+            candidates.append(dev)
+    if candidates:
+        return candidates[0]
+    # Fallback glob for macOS
+    for pattern in ("/dev/cu.usbserial*", "/dev/cu.wchusbserial*", "/dev/cu.usbmodem*"):
+        hits = glob.glob(pattern)
+        if hits:
+            return hits[0]
+    return None
+
+
+def list_all_ports() -> None:
+    print("Available serial ports:")
+    for p in list_ports.comports():
+        print(f"  {p.device}  ({p.description})")
+
+
+def read_until_ok(ser: serial.Serial, timeout: float = 5.0) -> str:
+    """Read lines from serial until we see 'ok' or timeout. Returns combined text."""
+    end = time.time() + timeout
+    out = []
+    while time.time() < end:
+        line = ser.readline().decode(errors="replace").strip()
+        if not line:
+            continue
+        out.append(line)
+        if line.lower().startswith("ok"):
+            break
+    return "\n".join(out)
+
+
+def send(ser: serial.Serial, gcode: str, *, echo: bool = True) -> str:
+    line = gcode.strip()
+    if not line:
+        return ""
+    ser.write((line + "\n").encode())
+    ser.flush()
+    resp = read_until_ok(ser)
+    if echo:
+        print(f">>> {line}")
+        if resp:
+            print(resp)
+    return resp
+
+
+def jog(ser: serial.Serial, axis: str, delta: float, feed: int) -> None:
+    # Use relative positioning so we always step from current location.
+    send(ser, "G91", echo=False)
+    send(ser, f"G1 {axis}{delta:.3f} F{feed}")
+    send(ser, "G90", echo=False)  # restore absolute mode
+
+
+HELP = __doc__
+
+
+def repl(ser: serial.Serial) -> None:
+    feed = JOG_FEED_DEFAULT
+    print(HELP)
+    print(f"(jog feed = {feed} mm/min)\n")
+
+    while True:
+        try:
+            raw = input("> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+        if not raw:
+            continue
+
+        parts = raw.split()
+        cmd = parts[0].lower()
+        arg = parts[1] if len(parts) > 1 else None
+
+        try:
+            if cmd in ("quit", "q", "exit"):
+                return
+            if cmd in ("help", "h", "?"):
+                print(HELP)
+                continue
+            if cmd == "home":
+                send(ser, "G28")
+                continue
+            if cmd == "pos":
+                send(ser, "M114")
+                continue
+            if cmd == "feed":
+                feed = int(arg)
+                print(f"jog feed set to {feed} mm/min")
+                continue
+            if cmd == "raw":
+                send(ser, raw[len("raw"):].strip())
+                continue
+
+            if cmd in ("up", "down", "left", "right", "z+", "z-",
+                       "u", "d", "l", "r"):
+                amount = float(arg) if arg is not None else 1.0
+                axis_map = {
+                    "up": ("Y", +1), "u": ("Y", +1),
+                    "down": ("Y", -1), "d": ("Y", -1),
+                    "right": ("X", +1), "r": ("X", +1),
+                    "left": ("X", -1), "l": ("X", -1),
+                    "z+": ("Z", +1),
+                    "z-": ("Z", -1),
+                }
+                axis, sign = axis_map[cmd]
+                jog(ser, axis, sign * amount, feed)
+                continue
+
+            print(f"unknown command: {cmd!r}  (type 'help')")
+        except Exception as e:
+            print(f"error: {e}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", help="serial port (autodetected if omitted)")
+    ap.add_argument("--baud", type=int, default=DEFAULT_BAUD)
+    ap.add_argument("--list", action="store_true", help="list serial ports and exit")
+    args = ap.parse_args()
+
+    if args.list:
+        list_all_ports()
+        return 0
+
+    port = args.port or find_port()
+    if not port:
+        print("No printer serial port found.")
+        list_all_ports()
+        print("\nIf nothing matching usbserial/usbmodem appears:")
+        print("  - confirm the printer is powered on and the USB cable is data-capable")
+        print("  - install the CH340 driver (most Creality boards use CH340)")
+        print("  - then re-run this script, or pass --port explicitly")
+        return 1
+
+    print(f"Connecting to {port} @ {args.baud}...")
+    ser = serial.Serial(port, args.baud, timeout=1)
+    # Many Marlin boards reset on serial open; wait for the boot banner.
+    time.sleep(2.0)
+    ser.reset_input_buffer()
+
+    # Probe firmware so we know we're talking to it.
+    send(ser, "M115")
+    repl(ser)
+    ser.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/paint-app/index.html
+++ b/paint-app/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>paint-app</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/paint-app/package-lock.json
+++ b/paint-app/package-lock.json
@@ -1,0 +1,2228 @@
+{
+  "name": "paint-app",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "paint-app",
+      "version": "0.0.0",
+      "dependencies": {
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.1",
+        "@mui/icons-material": "^9.0.1",
+        "@mui/material": "^9.0.1",
+        "dexie": "^4.4.2",
+        "framer-motion": "^12.38.0",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
+        "zod": "^4.4.3"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.14",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.1",
+        "typescript": "^6.0.3",
+        "vite": "^8.0.11"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
+      "integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.14",
+        "@biomejs/cli-darwin-x64": "2.4.14",
+        "@biomejs/cli-linux-arm64": "2.4.14",
+        "@biomejs/cli-linux-arm64-musl": "2.4.14",
+        "@biomejs/cli-linux-x64": "2.4.14",
+        "@biomejs/cli-linux-x64-musl": "2.4.14",
+        "@biomejs/cli-win32-arm64": "2.4.14",
+        "@biomejs/cli-win32-x64": "2.4.14"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.14.tgz",
+      "integrity": "sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.14.tgz",
+      "integrity": "sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.14.tgz",
+      "integrity": "sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.14.tgz",
+      "integrity": "sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.14.tgz",
+      "integrity": "sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.14.tgz",
+      "integrity": "sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.14.tgz",
+      "integrity": "sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.14.tgz",
+      "integrity": "sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+      "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mui/core-downloads-tracker": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.0.1.tgz",
+      "integrity": "sha512-GzamIIhZ1bH77dq7eKaeyRgJdkypsxin4jBFq2EMs4lBWRR0LFO1CSVMsoebn/VvjcNrnrOrjy48MkrkQUK2iw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-9.0.1.tgz",
+      "integrity": "sha512-5PRpQjVLTNLyV/2J9J53Yz4R0tVbodG0BQDN2zQI1QBG1OPYM25ar+4N20eyFOfJT6zKglLzsnU70+zdVLaTkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^9.0.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.0.1.tgz",
+      "integrity": "sha512-voyCpeUxcSWLN7KPZuq0pGCIt726T9K6kiVM3XUcywZDAlZSarLHaUxJVQpospbjjOzN53hwyjo8s6KoWl6utw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/core-downloads-tracker": "^9.0.1",
+        "@mui/system": "^9.0.1",
+        "@mui/types": "^9.0.0",
+        "@mui/utils": "^9.0.1",
+        "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.4",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material-pigment-css": "^9.0.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/private-theming": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.0.1.tgz",
+      "integrity": "sha512-pSIGq4Yw749KHEwlkYZWVERgHgwJELP6ODtBNUfV8V4oIb5H+h7IQDFXuk/b2oQccODK1enJAtiEzlgLZmq+8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/utils": "^9.0.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/styled-engine": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.0.0.tgz",
+      "integrity": "sha512-9RLGdX4Jg0aQPRuvqh/OLzYSPlgd5zyEw5/1HIRfdavSiOd03WtUaGZH9/w1RoTYuRKwpgy0hpIFaMHIqPVIWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.0.1.tgz",
+      "integrity": "sha512-WvlioaLxk6ewUIOfh0StxUvOPDS1mCfzaulcudsL1brZNXuh0N9FMk7RpH7ImJKjEz412SEy/V/yvqmtxbqxCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/private-theming": "^9.0.1",
+        "@mui/styled-engine": "^9.0.0",
+        "@mui/types": "^9.0.0",
+        "@mui/utils": "^9.0.1",
+        "clsx": "^2.1.1",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/types": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.0.0.tgz",
+      "integrity": "sha512-i1cuFCAWN44b3AJWO7mh7tuh1sqbQSeVr/94oG0TX5uXivac8XalgE4/6fQZcmGZigzbQ35IXxj/4jLpRIBYZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.0.1.tgz",
+      "integrity": "sha512-f3UO3jNN1pYg5zxqXC81Bvv8hx5ACcYc0387382ZI7M5ono1heIwHYLrKsz85myguWdeVKPRZGmDdynWUBjK2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/types": "^9.0.0",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.128.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
+      "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
+      "integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
+      "integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
+      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
+      "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-rc.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dexie": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.4.2.tgz",
+      "integrity": "sha512-zMtV8q79EFE5U8FKZvt0Y/77PCU/Hr/RDxv1EDeo228L+m/HTbeN2AjoQm674rhQCX8n3ljK87lajt7UQuZfvw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
+    },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "license": "MIT"
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
+      "integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.128.0",
+        "@rolldown/pluginutils": "1.0.0-rc.18"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.18",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
+      "integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
+      "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0-rc.18",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/paint-app/package.json
+++ b/paint-app/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "paint-app",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "biome check src",
+    "format": "biome format --write src",
+    "check": "biome check --write src"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^9.0.1",
+    "@mui/material": "^9.0.1",
+    "dexie": "^4.4.2",
+    "framer-motion": "^12.38.0",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.14",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.11"
+  }
+}

--- a/paint-app/src/App.tsx
+++ b/paint-app/src/App.tsx
@@ -1,0 +1,140 @@
+import { CssBaseline, createTheme, ThemeProvider } from '@mui/material';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { BottomBar } from './components/BottomBar';
+import { Canvas } from './components/Canvas';
+import { LayersPanel } from './components/LayersPanel';
+import { PrintModal } from './components/PrintModal';
+import { ProjectGate } from './components/ProjectGate';
+import { Toolbar } from './components/Toolbar';
+import { ConnectionProvider, useConnection } from './connection';
+import { useInteractiveSync } from './interactive';
+import { PlottersProvider } from './plotters';
+import { INTERACTIVE_PROJECT_ID, ProjectProvider, useProject } from './project';
+import { StoreProvider } from './store';
+import { UIProvider } from './ui';
+
+const theme = createTheme({
+  palette: { mode: 'light' },
+  shape: { borderRadius: 6 },
+});
+
+export const App = () => {
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <ConnectionProvider>
+        <StoreProvider>
+          <PlottersProvider>
+            <ProjectProvider>
+              <UIProvider>
+                <Root />
+              </UIProvider>
+            </ProjectProvider>
+          </PlottersProvider>
+        </StoreProvider>
+      </ConnectionProvider>
+    </ThemeProvider>
+  );
+};
+
+const Root = () => {
+  const { project } = useProject();
+  const { log, showLog } = useConnection();
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <div style={{ flex: 1, minHeight: 0 }}>{project ? <Shell /> : <ProjectGate />}</div>
+      {showLog && <LogPanel lines={log} />}
+    </div>
+  );
+};
+
+const Shell = () => {
+  const [printing, setPrinting] = useState(false);
+  const { project } = useProject();
+  const isInteractive = project?.id === INTERACTIVE_PROJECT_ID;
+  useInteractiveSync();
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <Toolbar onPrint={() => setPrinting(true)} />
+      <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
+        {!isInteractive && <LayersPanel />}
+        <Canvas />
+      </div>
+      <BottomBar />
+      {printing && <PrintModal onClose={() => setPrinting(false)} />}
+    </div>
+  );
+};
+
+const LOG_HEIGHT_LS_KEY = 'paint-app:logHeight';
+const MIN_LOG_HEIGHT = 60;
+
+const LogPanel = ({ lines }: { lines: string[] }) => {
+  const [height, setHeight] = useState(() => {
+    const raw = Number(localStorage.getItem(LOG_HEIGHT_LS_KEY));
+    return raw >= MIN_LOG_HEIGHT ? raw : 120;
+  });
+
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  // Always pin to the bottom so the newest line is in view.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-run on each new line
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [lines]);
+
+  const onHandleDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    const startY = e.clientY;
+    const startHeight = e.currentTarget.parentElement?.offsetHeight ?? 120;
+    const onMove = (ev: MouseEvent) => {
+      const max = window.innerHeight * 0.8;
+      const next = Math.min(max, Math.max(MIN_LOG_HEIGHT, startHeight + (startY - ev.clientY)));
+      setHeight(next);
+    };
+    const onUp = () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+      setHeight((h) => {
+        localStorage.setItem(LOG_HEIGHT_LS_KEY, String(Math.round(h)));
+        return h;
+      });
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  }, []);
+
+  return (
+    <div
+      style={{
+        height,
+        borderTop: '1px solid #e0e0e0',
+        background: '#111',
+        color: '#ddd',
+        fontFamily: 'ui-monospace, Menlo, monospace',
+        fontSize: 12,
+        display: 'flex',
+        flexDirection: 'column',
+        flexShrink: 0,
+      }}
+    >
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: drag-resize handle */}
+      <div
+        onMouseDown={onHandleDown}
+        title="Drag to resize log"
+        style={{
+          height: 8,
+          cursor: 'ns-resize',
+          background: '#222',
+          borderBottom: '1px solid #333',
+          flexShrink: 0,
+        }}
+      />
+      <div ref={scrollRef} style={{ padding: 8, overflowY: 'auto', whiteSpace: 'pre', flex: 1 }}>
+        {lines.length === 0 ? <span style={{ color: '#666' }}>log…</span> : lines.join('\n')}
+      </div>
+    </div>
+  );
+};

--- a/paint-app/src/clip.ts
+++ b/paint-app/src/clip.ts
@@ -1,0 +1,79 @@
+import type { Point } from './types';
+
+export type Rect = { x: number; y: number; width: number; height: number };
+
+/**
+ * Liang-Barsky line clipping. Returns the portion of segment [p1, p2]
+ * that lies inside `rect`, or null if the segment is fully outside.
+ */
+const clipSegment = (p1: Point, p2: Point, rect: Rect): [Point, Point] | null => {
+  const xmin = rect.x;
+  const ymin = rect.y;
+  const xmax = rect.x + rect.width;
+  const ymax = rect.y + rect.height;
+  let t0 = 0;
+  let t1 = 1;
+  const dx = p2.x - p1.x;
+  const dy = p2.y - p1.y;
+  const tests: { p: number; q: number }[] = [
+    { p: -dx, q: p1.x - xmin },
+    { p: dx, q: xmax - p1.x },
+    { p: -dy, q: p1.y - ymin },
+    { p: dy, q: ymax - p1.y },
+  ];
+  for (const { p, q } of tests) {
+    if (p === 0) {
+      if (q < 0) return null;
+    } else {
+      const t = q / p;
+      if (p < 0) {
+        if (t > t1) return null;
+        if (t > t0) t0 = t;
+      } else {
+        if (t < t0) return null;
+        if (t < t1) t1 = t;
+      }
+    }
+  }
+  return [
+    { x: p1.x + t0 * dx, y: p1.y + t0 * dy },
+    { x: p1.x + t1 * dx, y: p1.y + t1 * dy },
+  ];
+};
+
+/**
+ * Clip a polyline (sequence of connected points) against a rectangle,
+ * returning zero or more sub-polylines (each of length ≥ 2) that lie inside.
+ *
+ * Each consecutive segment is clipped independently; runs of consecutive
+ * inside-segments are merged into a single sub-polyline.
+ */
+export const clipPolyline = (points: Point[], rect: Rect): Point[][] => {
+  const out: Point[][] = [];
+  let current: Point[] = [];
+
+  const flush = () => {
+    if (current.length >= 2) out.push(current);
+    current = [];
+  };
+
+  for (let i = 0; i < points.length - 1; i++) {
+    const seg = clipSegment(points[i], points[i + 1], rect);
+    if (!seg) {
+      flush();
+      continue;
+    }
+    if (current.length === 0) {
+      current.push(seg[0]);
+    } else {
+      const last = current[current.length - 1];
+      if (last.x !== seg[0].x || last.y !== seg[0].y) {
+        flush();
+        current.push(seg[0]);
+      }
+    }
+    current.push(seg[1]);
+  }
+  flush();
+  return out;
+};

--- a/paint-app/src/components/BottomBar.tsx
+++ b/paint-app/src/components/BottomBar.tsx
@@ -1,0 +1,321 @@
+import AddIcon from '@mui/icons-material/Add';
+import CircleOutlinedIcon from '@mui/icons-material/CircleOutlined';
+import CodeIcon from '@mui/icons-material/Code';
+import CreateIcon from '@mui/icons-material/Create';
+import HexagonOutlinedIcon from '@mui/icons-material/HexagonOutlined';
+import HorizontalRuleIcon from '@mui/icons-material/HorizontalRule';
+import ClearIcon from '@mui/icons-material/LayersClear';
+import RectangleOutlinedIcon from '@mui/icons-material/RectangleOutlined';
+import RemoveIcon from '@mui/icons-material/Remove';
+import StarBorderIcon from '@mui/icons-material/StarBorder';
+import UndoIcon from '@mui/icons-material/Undo';
+import { Box, Divider, IconButton, Paper, Popover, TextField, Tooltip } from '@mui/material';
+import { type ReactNode, useEffect, useState } from 'react';
+import { INTERACTIVE_PROJECT_ID, useProject } from '../project';
+import { useStore } from '../store';
+import { type Tool, useUI } from '../ui';
+import { ZOOM_MAX, ZOOM_MIN } from './Canvas';
+import { ScriptDialog } from './ScriptDialog';
+
+const TOOLS: { key: Tool; label: string; icon: ReactNode; hint: string }[] = [
+  { key: 'pen', label: 'Pen', icon: <CreateIcon />, hint: 'Freehand drawing' },
+  {
+    key: 'line',
+    label: 'Line',
+    icon: <HorizontalRuleIcon />,
+    hint: 'Drag to draw a straight line',
+  },
+  {
+    key: 'rect',
+    label: 'Rectangle',
+    icon: <RectangleOutlinedIcon />,
+    hint: 'Drag a bounding box',
+  },
+  {
+    key: 'ellipse',
+    label: 'Ellipse',
+    icon: <CircleOutlinedIcon />,
+    hint: 'Drag a bounding box',
+  },
+  {
+    key: 'polygon',
+    label: 'Polygon',
+    icon: <HexagonOutlinedIcon />,
+    hint: 'Drag from center to a vertex',
+  },
+  {
+    key: 'star',
+    label: 'Star',
+    icon: <StarBorderIcon />,
+    hint: 'Drag from center to an outer point',
+  },
+];
+
+const PRESET_COLORS = [
+  '#000000',
+  '#e53935',
+  '#fb8c00',
+  '#fdd835',
+  '#43a047',
+  '#00897b',
+  '#1e88e5',
+  '#3949ab',
+  '#8e24aa',
+  '#d81b60',
+  '#6d4c41',
+  '#757575',
+];
+
+export const BottomBar = () => {
+  const {
+    tool,
+    setTool,
+    polygonSides,
+    setPolygonSides,
+    starPoints,
+    setStarPoints,
+    zoom,
+    setZoom,
+    drawColor,
+    setDrawColor,
+  } = useUI();
+  const { clearStrokes, undo, canUndo } = useStore();
+  const { project } = useProject();
+  const isInteractive = project?.id === INTERACTIVE_PROJECT_ID;
+  const undoDisabled = isInteractive || !canUndo;
+  const [scriptOpen, setScriptOpen] = useState(false);
+  const [colorAnchor, setColorAnchor] = useState<HTMLElement | null>(null);
+
+  const activeColor = drawColor;
+  const setColor = (c: string) => setDrawColor(c);
+
+  const onClear = () => {
+    if (confirm('Clear all strokes? This cannot be undone in an interactive session.')) {
+      clearStrokes();
+    }
+  };
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey)) return;
+      if (e.key.toLowerCase() !== 'z') return;
+      // Don't hijack while typing in inputs.
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
+      ) {
+        return;
+      }
+      if (undoDisabled) return;
+      e.preventDefault();
+      undo();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [undo, undoDisabled]);
+
+  return (
+    <Paper
+      elevation={4}
+      sx={{
+        position: 'fixed',
+        bottom: 16,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.5,
+        px: 1,
+        py: 0.5,
+        borderRadius: 2,
+        zIndex: 20,
+      }}
+    >
+      {TOOLS.map((t) => (
+        <Tooltip key={t.key} title={`${t.label} — ${t.hint}`}>
+          <IconButton
+            size="small"
+            onClick={() => setTool(t.key)}
+            sx={{
+              border: '1px solid',
+              borderColor: tool === t.key ? 'primary.main' : 'transparent',
+              color: tool === t.key ? 'primary.main' : 'text.primary',
+              borderRadius: 1,
+            }}
+          >
+            {t.icon}
+          </IconButton>
+        </Tooltip>
+      ))}
+
+      {tool === 'polygon' && (
+        <TextField
+          label="sides"
+          size="small"
+          type="number"
+          value={polygonSides}
+          onChange={(e) => setPolygonSides(Math.max(3, Number.parseInt(e.target.value, 10) || 3))}
+          slotProps={{ htmlInput: { min: 3, max: 32, style: { padding: 4, fontSize: 12 } } }}
+          sx={{ width: 64, ml: 0.5 }}
+        />
+      )}
+      {tool === 'star' && (
+        <TextField
+          label="pts"
+          size="small"
+          type="number"
+          value={starPoints}
+          onChange={(e) => setStarPoints(Math.max(3, Number.parseInt(e.target.value, 10) || 3))}
+          slotProps={{ htmlInput: { min: 3, max: 32, style: { padding: 4, fontSize: 12 } } }}
+          sx={{ width: 64, ml: 0.5 }}
+        />
+      )}
+
+      <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
+
+      <Tooltip title="Color">
+        <IconButton size="small" onClick={(e) => setColorAnchor(e.currentTarget)}>
+          <Box
+            sx={{
+              width: 18,
+              height: 18,
+              borderRadius: '50%',
+              background: activeColor,
+              border: '1px solid rgba(0,0,0,0.3)',
+            }}
+          />
+        </IconButton>
+      </Tooltip>
+      <Popover
+        open={Boolean(colorAnchor)}
+        anchorEl={colorAnchor}
+        onClose={() => setColorAnchor(null)}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Box sx={{ p: 1 }}>
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(6, 1fr)',
+              gap: 0.5,
+              mb: 1,
+            }}
+          >
+            {PRESET_COLORS.map((c) => (
+              <Box
+                key={c}
+                component="button"
+                type="button"
+                aria-label={c}
+                onClick={() => {
+                  setColor(c);
+                  setColorAnchor(null);
+                }}
+                sx={{
+                  width: 24,
+                  height: 24,
+                  p: 0,
+                  borderRadius: '50%',
+                  cursor: 'pointer',
+                  background: c,
+                  border:
+                    c.toLowerCase() === activeColor.toLowerCase()
+                      ? '2px solid #1976d2'
+                      : '1px solid rgba(0,0,0,0.3)',
+                }}
+              />
+            ))}
+          </Box>
+          <Box
+            component="label"
+            sx={{ display: 'flex', alignItems: 'center', gap: 1, fontSize: 13, cursor: 'pointer' }}
+          >
+            Custom
+            <input
+              type="color"
+              value={activeColor}
+              onChange={(e) => setColor(e.target.value)}
+              style={{ width: 32, height: 24, border: 'none', background: 'none', padding: 0 }}
+            />
+          </Box>
+        </Box>
+      </Popover>
+
+      {isInteractive && (
+        <Tooltip title="Clear all strokes">
+          <IconButton size="small" onClick={onClear}>
+            <ClearIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      )}
+
+      <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
+
+      <Tooltip title="Script — generate strokes from JS">
+        <IconButton size="small" onClick={() => setScriptOpen(true)}>
+          <CodeIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+
+      <Tooltip
+        title={
+          isInteractive
+            ? 'Undo is disabled in interactive sessions'
+            : canUndo
+              ? 'Undo (⌘Z)'
+              : 'Nothing to undo'
+        }
+      >
+        <span>
+          <IconButton size="small" onClick={undo} disabled={undoDisabled}>
+            <UndoIcon fontSize="small" />
+          </IconButton>
+        </span>
+      </Tooltip>
+
+      <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
+
+      <Tooltip title="Zoom out">
+        <IconButton
+          size="small"
+          onClick={() => setZoom((z) => Math.max(ZOOM_MIN, z / 1.2))}
+          disabled={zoom <= ZOOM_MIN + 1e-6}
+        >
+          <RemoveIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Reset zoom">
+        <Box
+          component="button"
+          type="button"
+          onClick={() => setZoom(1)}
+          sx={{
+            minWidth: 52,
+            border: 'none',
+            background: 'none',
+            cursor: 'pointer',
+            fontFamily: 'inherit',
+            fontSize: 13,
+            color: 'text.secondary',
+            px: 0.5,
+          }}
+        >
+          {Math.round(zoom * 100)}%
+        </Box>
+      </Tooltip>
+      <Tooltip title="Zoom in">
+        <IconButton
+          size="small"
+          onClick={() => setZoom((z) => Math.min(ZOOM_MAX, z * 1.2))}
+          disabled={zoom >= ZOOM_MAX - 1e-6}
+        >
+          <AddIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+
+      <ScriptDialog open={scriptOpen} onClose={() => setScriptOpen(false)} />
+    </Paper>
+  );
+};

--- a/paint-app/src/components/Canvas.tsx
+++ b/paint-app/src/components/Canvas.tsx
@@ -1,0 +1,491 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { INTERACTIVE_PROJECT_ID, useProject } from '../project';
+import { buildEllipse, buildLine, buildPolygon, buildRect, buildStar } from '../shapes';
+import { type AddDirection, useStore } from '../store';
+import type { Page, Point } from '../types';
+import { type Tool, useUI } from '../ui';
+
+const PX_PER_MM = 3;
+const PADDING_MM = 60;
+const ADD_BUTTON_R = 5;
+const ADD_BUTTON_GAP = 3;
+const REMOVE_BUTTON_R = 3;
+const REMOVE_BUTTON_INSET = 4;
+export const ZOOM_MIN = 0.2;
+export const ZOOM_MAX = 5;
+
+type DrawingState =
+  | { kind: 'pen'; points: Point[] }
+  | { kind: 'shape'; tool: Exclude<Tool, 'pen'>; start: Point; current: Point };
+
+export const Canvas = () => {
+  const { state, addPage, addStroke, setActivePage, removePage } = useStore();
+  const { project } = useProject();
+  const {
+    tool,
+    polygonSides,
+    starPoints,
+    zoom,
+    setZoom,
+    showGrid,
+    gridSize,
+    drawColor,
+    scriptPreview,
+  } = useUI();
+  const { pages, layers, activePageId, activeLayerId } = state;
+  const [drawing, setDrawing] = useState<DrawingState | null>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const activeLayer = layers.find((l) => l.id === activeLayerId);
+  const activePage = pages.find((p) => p.id === activePageId) ?? pages[0];
+  // Interactive sessions are single-page by definition — every stroke is
+  // streamed to the plotter immediately, so multi-page layout would be
+  // ambiguous. Hide the add/remove page UI entirely in that mode.
+  const isInteractive = project?.id === INTERACTIVE_PROJECT_ID;
+  const allowPageEdits = !isInteractive;
+
+  // World bounds: bbox of pages + 4 add-buttons of the active page + padding.
+  // Interactive sessions are single-page and fit-to-screen, so use a tight
+  // margin around the active page rather than the generous scroll padding.
+  const bounds = useMemo(() => {
+    if (isInteractive) {
+      const m = 8;
+      return {
+        x: activePage.x - m,
+        y: activePage.y - m,
+        width: activePage.width + m * 2,
+        height: activePage.height + m * 2,
+      };
+    }
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (const p of pages) {
+      if (p.x < minX) minX = p.x;
+      if (p.y < minY) minY = p.y;
+      if (p.x + p.width > maxX) maxX = p.x + p.width;
+      if (p.y + p.height > maxY) maxY = p.y + p.height;
+    }
+    const pad = ADD_BUTTON_GAP + ADD_BUTTON_R * 2 + 2;
+    minX = Math.min(minX, activePage.x - pad);
+    minY = Math.min(minY, activePage.y - pad);
+    maxX = Math.max(maxX, activePage.x + activePage.width + pad);
+    maxY = Math.max(maxY, activePage.y + activePage.height + pad);
+    return {
+      x: minX - PADDING_MM,
+      y: minY - PADDING_MM,
+      width: maxX - minX + PADDING_MM * 2,
+      height: maxY - minY + PADDING_MM * 2,
+    };
+  }, [pages, activePage, isInteractive]);
+
+  // Map screen → world via the SVG's own transform matrix. This stays correct
+  // regardless of how the viewBox is fitted (scroll-sized 1:1 or
+  // preserveAspectRatio letterboxing in interactive fit-to-screen mode).
+  const clientToWorld = (clientX: number, clientY: number): Point | null => {
+    const svg = svgRef.current;
+    const ctm = svg?.getScreenCTM();
+    if (!svg || !ctm) return null;
+    const pt = svg.createSVGPoint();
+    pt.x = clientX;
+    pt.y = clientY;
+    const sp = pt.matrixTransform(ctm.inverse());
+    return { x: sp.x, y: sp.y };
+  };
+
+  const findPageAt = (pt: Point): Page | null => {
+    for (let i = pages.length - 1; i >= 0; i--) {
+      const p = pages[i];
+      if (pt.x >= p.x && pt.x <= p.x + p.width && pt.y >= p.y && pt.y <= p.y + p.height) {
+        return p;
+      }
+    }
+    return null;
+  };
+
+  const buildShapePoints = (start: Point, current: Point, t: Exclude<Tool, 'pen'>): Point[] => {
+    switch (t) {
+      case 'line':
+        return buildLine(start, current);
+      case 'rect':
+        return buildRect(start, current);
+      case 'ellipse':
+        return buildEllipse(start, current);
+      case 'polygon':
+        return buildPolygon(start, current, polygonSides);
+      case 'star':
+        return buildStar(start, current, starPoints);
+    }
+  };
+
+  const onPointerDown = (e: React.PointerEvent<SVGSVGElement>) => {
+    if (!activeLayer) return;
+    if (e.button !== 0) return;
+    const pt = clientToWorld(e.clientX, e.clientY);
+    if (!pt) return;
+    // Drawing must start on a page. Off-page starts would produce strokes that
+    // get fully clipped at print time — confusing UX.
+    const page = findPageAt(pt);
+    if (!page) return;
+    setActivePage(page.id);
+    svgRef.current?.setPointerCapture(e.pointerId);
+    if (tool === 'pen') {
+      setDrawing({ kind: 'pen', points: [pt] });
+    } else {
+      setDrawing({ kind: 'shape', tool, start: pt, current: pt });
+    }
+  };
+
+  const onPointerMove = (e: React.PointerEvent<SVGSVGElement>) => {
+    if (!drawing) return;
+    const pt = clientToWorld(e.clientX, e.clientY);
+    if (!pt) return;
+    const onPage = findPageAt(pt) !== null;
+
+    if (drawing.kind === 'pen') {
+      // Confine freehand to the union of pages. When the cursor leaves the
+      // page collection, commit the in-progress points as a stroke and clear
+      // the buffer; dragging back onto a page begins a new sub-stroke without
+      // lifting the pointer.
+      if (!onPage) {
+        if (drawing.points.length >= 2 && activeLayer) {
+          addStroke(activeLayer.id, drawing.points, drawColor);
+        }
+        setDrawing({ kind: 'pen', points: [] });
+        return;
+      }
+      if (drawing.points.length === 0) {
+        setDrawing({ kind: 'pen', points: [pt] });
+        return;
+      }
+      setDrawing({ kind: 'pen', points: [...drawing.points, pt] });
+      return;
+    }
+
+    // Shape tools: only update the live "current" point while the cursor is
+    // on a page; off-page movement freezes the preview at the last on-page
+    // position so the committed shape stays inside the document.
+    if (!onPage) return;
+    setDrawing({ ...drawing, current: pt });
+  };
+
+  const onPointerUp = (e: React.PointerEvent<SVGSVGElement>) => {
+    if (!drawing) return;
+    svgRef.current?.releasePointerCapture(e.pointerId);
+    if (drawing.kind === 'pen') {
+      if (drawing.points.length >= 2 && activeLayer) {
+        addStroke(activeLayer.id, drawing.points, drawColor);
+      }
+    } else if (activeLayer) {
+      const points = buildShapePoints(drawing.start, drawing.current, drawing.tool);
+      // Skip degenerate shapes (zero-radius, etc.).
+      if (points.length >= 2) {
+        const dx = drawing.current.x - drawing.start.x;
+        const dy = drawing.current.y - drawing.start.y;
+        if (Math.hypot(dx, dy) > 0.5) {
+          addStroke(activeLayer.id, points, drawColor);
+        }
+      }
+    }
+    setDrawing(null);
+  };
+
+  const previewPoints: Point[] | null = !drawing
+    ? null
+    : drawing.kind === 'pen'
+      ? drawing.points
+      : buildShapePoints(drawing.start, drawing.current, drawing.tool);
+
+  // Cmd/Ctrl + Wheel zooms (centered on cursor); otherwise the browser
+  // scrolls the overflow container natively.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      if (!(e.ctrlKey || e.metaKey)) return;
+      e.preventDefault();
+      const factor = e.deltaY > 0 ? 1 / 1.1 : 1.1;
+      const before = el.getBoundingClientRect();
+      const cursorX = e.clientX - before.left + el.scrollLeft;
+      const cursorY = e.clientY - before.top + el.scrollTop;
+      setZoom((z) => {
+        const next = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, z * factor));
+        const ratio = next / z;
+        requestAnimationFrame(() => {
+          el.scrollLeft = cursorX * ratio - (e.clientX - before.left);
+          el.scrollTop = cursorY * ratio - (e.clientY - before.top);
+        });
+        return next;
+      });
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, [setZoom]);
+
+  const wPx = bounds.width * PX_PER_MM * zoom;
+  const hPx = bounds.height * PX_PER_MM * zoom;
+
+  const addButtons: { dir: AddDirection; cx: number; cy: number }[] = [
+    {
+      dir: 'top',
+      cx: activePage.x + activePage.width / 2,
+      cy: activePage.y - ADD_BUTTON_GAP - ADD_BUTTON_R,
+    },
+    {
+      dir: 'right',
+      cx: activePage.x + activePage.width + ADD_BUTTON_GAP + ADD_BUTTON_R,
+      cy: activePage.y + activePage.height / 2,
+    },
+    {
+      dir: 'bottom',
+      cx: activePage.x + activePage.width / 2,
+      cy: activePage.y + activePage.height + ADD_BUTTON_GAP + ADD_BUTTON_R,
+    },
+    {
+      dir: 'left',
+      cx: activePage.x - ADD_BUTTON_GAP - ADD_BUTTON_R,
+      cy: activePage.y + activePage.height / 2,
+    },
+  ];
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        flex: 1,
+        overflow: isInteractive ? 'hidden' : 'auto',
+        background: '#f0f0f0',
+        position: 'relative',
+      }}
+    >
+      <svg
+        ref={svgRef}
+        role="img"
+        aria-label="Canvas"
+        width={isInteractive ? '100%' : wPx}
+        height={isInteractive ? '100%' : hPx}
+        viewBox={`${bounds.x} ${bounds.y} ${bounds.width} ${bounds.height}`}
+        preserveAspectRatio="xMidYMid meet"
+        style={{ display: 'block', cursor: 'crosshair', touchAction: 'none' }}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+      >
+        {showGrid && (
+          <defs>
+            {/* userSpaceOnUse keeps grid lines aligned to world (mm)
+                coordinates, so they stay continuous across adjacent pages. */}
+            <pattern
+              id="page-grid"
+              patternUnits="userSpaceOnUse"
+              width={gridSize}
+              height={gridSize}
+            >
+              <path
+                d={`M ${gridSize} 0 L 0 0 0 ${gridSize}`}
+                fill="none"
+                stroke="#c8d4e0"
+                strokeWidth={0.2}
+              />
+            </pattern>
+          </defs>
+        )}
+
+        {pages.map((page) => {
+          const isActive = page.id === activePageId;
+          return (
+            <g key={page.id}>
+              <rect
+                x={page.x}
+                y={page.y}
+                width={page.width}
+                height={page.height}
+                fill="#fff"
+                stroke={isActive ? '#4a90e2' : '#bbb'}
+                strokeWidth={isActive ? 1.2 : 0.4}
+              />
+              {showGrid && (
+                <rect
+                  x={page.x}
+                  y={page.y}
+                  width={page.width}
+                  height={page.height}
+                  fill="url(#page-grid)"
+                  pointerEvents="none"
+                />
+              )}
+              {allowPageEdits && pages.length > 1 && (
+                <RemoveButton
+                  cx={page.x + page.width - REMOVE_BUTTON_INSET - REMOVE_BUTTON_R}
+                  cy={page.y + REMOVE_BUTTON_INSET + REMOVE_BUTTON_R}
+                  onConfirm={() => removePage(page.id)}
+                />
+              )}
+            </g>
+          );
+        })}
+
+        {layers.map(
+          (layer) =>
+            layer.visible && (
+              <g key={layer.id}>
+                {layer.strokes.map((stroke) => (
+                  <polyline
+                    key={stroke.id}
+                    points={stroke.points.map((p) => `${p.x},${p.y}`).join(' ')}
+                    fill="none"
+                    stroke={stroke.color ?? layer.color}
+                    strokeWidth={layer.thickness}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                ))}
+              </g>
+            ),
+        )}
+
+        {previewPoints && previewPoints.length >= 2 && activeLayer && (
+          <polyline
+            points={previewPoints.map((p) => `${p.x},${p.y}`).join(' ')}
+            fill="none"
+            stroke={drawColor}
+            strokeWidth={activeLayer.thickness}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        )}
+
+        {scriptPreview && activeLayer && (
+          <g opacity={0.45}>
+            {scriptPreview.map((points, i) =>
+              points.length < 2 ? null : (
+                <polyline
+                  // biome-ignore lint/suspicious/noArrayIndexKey: preview list is regenerated whole each tick
+                  key={i}
+                  points={points.map((p) => `${p.x},${p.y}`).join(' ')}
+                  fill="none"
+                  stroke={drawColor}
+                  strokeWidth={activeLayer.thickness}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeDasharray="2 2"
+                />
+              ),
+            )}
+          </g>
+        )}
+
+        {allowPageEdits &&
+          addButtons.map((b) => (
+            <AddButton key={b.dir} cx={b.cx} cy={b.cy} onClick={() => addPage(b.dir)} />
+          ))}
+      </svg>
+    </div>
+  );
+};
+
+const AddButton = ({ cx, cy, onClick }: { cx: number; cy: number; onClick: () => void }) => (
+  // biome-ignore lint/a11y/useSemanticElements: SVG <g> can't be a <button>; behaves like one.
+  <g
+    role="button"
+    aria-label="Add page"
+    tabIndex={0}
+    onPointerDown={(e) => e.stopPropagation()}
+    onClick={(e) => {
+      e.stopPropagation();
+      onClick();
+    }}
+    onKeyDown={(e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onClick();
+      }
+    }}
+    style={{ cursor: 'pointer' }}
+  >
+    <circle
+      cx={cx}
+      cy={cy}
+      r={ADD_BUTTON_R}
+      fill="#fff"
+      stroke="#aaa"
+      strokeWidth={0.4}
+      strokeDasharray="1.5 1"
+    />
+    <text
+      x={cx}
+      y={cy}
+      textAnchor="middle"
+      dominantBaseline="central"
+      fontSize={ADD_BUTTON_R * 1.4}
+      fill="#888"
+      style={{ userSelect: 'none', pointerEvents: 'none' }}
+    >
+      +
+    </text>
+  </g>
+);
+
+const RemoveButton = ({ cx, cy, onConfirm }: { cx: number; cy: number; onConfirm: () => void }) => {
+  const [armed, setArmed] = useState(false);
+
+  useEffect(() => {
+    if (!armed) return;
+    const t = setTimeout(() => setArmed(false), 2500);
+    return () => clearTimeout(t);
+  }, [armed]);
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: SVG <g> can't be a <button>; behaves like one.
+    <g
+      role="button"
+      aria-label={armed ? 'Confirm remove page' : 'Remove page'}
+      tabIndex={0}
+      onPointerDown={(e) => e.stopPropagation()}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (armed) {
+          setArmed(false);
+          onConfirm();
+        } else {
+          setArmed(true);
+        }
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          if (armed) {
+            setArmed(false);
+            onConfirm();
+          } else {
+            setArmed(true);
+          }
+        }
+      }}
+      style={{ cursor: 'pointer' }}
+    >
+      <circle
+        cx={cx}
+        cy={cy}
+        r={REMOVE_BUTTON_R}
+        fill={armed ? '#c33' : '#fff'}
+        stroke={armed ? '#c33' : '#bbb'}
+        strokeWidth={0.4}
+      />
+      <text
+        x={cx}
+        y={cy}
+        textAnchor="middle"
+        dominantBaseline="central"
+        fontSize={REMOVE_BUTTON_R * 1.6}
+        fill={armed ? '#fff' : '#888'}
+        style={{ userSelect: 'none', pointerEvents: 'none' }}
+      >
+        {armed ? '?' : '×'}
+      </text>
+    </g>
+  );
+};

--- a/paint-app/src/components/DebugModal.tsx
+++ b/paint-app/src/components/DebugModal.tsx
@@ -1,0 +1,301 @@
+import HomeIcon from '@mui/icons-material/Home';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useEffect, useState } from 'react';
+import { useConnection } from '../connection';
+import { usePlotters } from '../plotters';
+import { useStore } from '../store';
+
+type Props = {
+  onClose: () => void;
+};
+
+type Pos = { x: number; y: number; z: number };
+
+const JOG_STEPS = [0.1, 1, 10];
+
+/**
+ * Manual plotter test panel. Lets you fire individual G-code commands
+ * (home, pen up/down, jog, query position) to verify the machine is wired
+ * up and responding before committing to a full print.
+ */
+export const DebugModal = ({ onClose }: Props) => {
+  const { connection } = useConnection();
+  const { state } = useStore();
+  const { getPlotter } = usePlotters();
+  const plotter = getPlotter(state.plotterId) ?? null;
+  const activePage = state.pages.find((p) => p.id === state.activePageId) ?? state.pages[0];
+
+  const [busy, setBusy] = useState(false);
+  const [last, setLast] = useState<string>('');
+  const [step, setStep] = useState(10);
+  const [raw, setRaw] = useState('');
+  const [position, setPosition] = useState<Pos | null>(null);
+
+  const refreshPosition = async () => {
+    try {
+      const p = await connection.getPosition();
+      if (p) setPosition(p);
+    } catch {}
+  };
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: connection is stable; fetch once on open
+  useEffect(() => {
+    refreshPosition();
+  }, []);
+
+  const run = async (label: string, fn: () => Promise<unknown>) => {
+    if (busy) return;
+    setBusy(true);
+    setLast(`${label}…`);
+    try {
+      const out = await fn();
+      const text = Array.isArray(out)
+        ? out.join(' / ')
+        : out == null
+          ? ''
+          : typeof out === 'object'
+            ? JSON.stringify(out)
+            : String(out);
+      setLast(`${label}: ${text || 'ok'}`);
+    } catch (e) {
+      setLast(`${label} failed: ${(e as Error).message}`);
+    } finally {
+      await refreshPosition();
+      setBusy(false);
+    }
+  };
+
+  const send = (label: string, gcode: string) => run(label, () => connection.send(gcode));
+
+  const jog = (axis: 'X' | 'Y', dir: 1 | -1) =>
+    run(`Jog ${axis}${dir > 0 ? '+' : '-'}${step}`, async () => {
+      await connection.send('G91');
+      const out = await connection.send(`G0 ${axis}${dir * step}`);
+      await connection.send('G90');
+      return out;
+    });
+
+  const moveAbs = (label: string, axis: 'X' | 'Y', value: number) => {
+    if (!plotter) {
+      setLast(`${label} failed: no plotter selected`);
+      return;
+    }
+    run(label, async () => {
+      await connection.send('G90');
+      return connection.send(`G0 ${axis}${value} F${plotter.travelFeed}`);
+    });
+  };
+
+  const penUp = () =>
+    plotter
+      ? send('Pen up', `G0 Z${plotter.penUpZ} F${plotter.travelFeed}`)
+      : setLast('Pen up failed: no plotter selected');
+  const penDown = () =>
+    plotter
+      ? send('Pen down', `G1 Z${plotter.penDownZ} F${plotter.travelFeed}`)
+      : setLast('Pen down failed: no plotter selected');
+
+  const fmt = (n: number) => n.toFixed(2);
+
+  return (
+    <Dialog open onClose={onClose} fullWidth maxWidth="xs">
+      <DialogTitle>Plotter debug</DialogTitle>
+      <DialogContent dividers>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          Plotter: <strong>{plotter?.name ?? '— none —'}</strong>
+          {activePage && (
+            <>
+              {' · '}
+              {activePage.width} × {activePage.height} mm
+            </>
+          )}
+        </Typography>
+
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            mb: 2,
+            p: 1,
+            borderRadius: 1,
+            bgcolor: 'action.hover',
+            fontFamily: 'ui-monospace, Menlo, monospace',
+            fontSize: 13,
+          }}
+        >
+          <Box sx={{ flex: 1 }}>
+            {position
+              ? `X ${fmt(position.x)}   Y ${fmt(position.y)}   Z ${fmt(position.z)}`
+              : 'position —'}
+          </Box>
+          <IconButton size="small" disabled={busy} onClick={refreshPosition} title="Refresh">
+            <RefreshIcon fontSize="small" />
+          </IconButton>
+        </Box>
+
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+          <Button
+            size="small"
+            variant="outlined"
+            disabled={busy}
+            onClick={() => send('Disable steppers', 'M84')}
+          >
+            Disable steppers
+          </Button>
+        </Box>
+
+        <Divider sx={{ my: 2 }} />
+
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+          <Typography variant="body2">Jog step</Typography>
+          <Select
+            size="small"
+            value={step}
+            onChange={(e) => setStep(Number(e.target.value))}
+            sx={{ minWidth: 90 }}
+          >
+            {JOG_STEPS.map((s) => (
+              <MenuItem key={s} value={s}>
+                {s} mm
+              </MenuItem>
+            ))}
+          </Select>
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(3, 1fr)',
+              gap: 1,
+              maxWidth: 220,
+            }}
+          >
+            <Box />
+            <Button size="small" variant="outlined" disabled={busy} onClick={() => jog('Y', 1)}>
+              Y+
+            </Button>
+            <Box />
+            <Button size="small" variant="outlined" disabled={busy} onClick={() => jog('X', -1)}>
+              X−
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              disabled={busy}
+              onClick={() => send('Home', 'G28')}
+              title="Home (G28)"
+              sx={{ minWidth: 0 }}
+            >
+              <HomeIcon fontSize="small" />
+            </Button>
+            <Button size="small" variant="outlined" disabled={busy} onClick={() => jog('X', 1)}>
+              X+
+            </Button>
+            <Box />
+            <Button size="small" variant="outlined" disabled={busy} onClick={() => jog('Y', -1)}>
+              Y−
+            </Button>
+            <Box />
+          </Box>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <Button size="small" variant="outlined" disabled={busy} onClick={penUp}>
+              Pen up
+            </Button>
+            <Button size="small" variant="outlined" disabled={busy} onClick={penDown}>
+              Pen down
+            </Button>
+          </Box>
+        </Box>
+
+        <Divider sx={{ my: 2 }} />
+
+        <Typography variant="body2" sx={{ mb: 1 }}>
+          Bed extremes
+        </Typography>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+          <Button
+            size="small"
+            variant="outlined"
+            disabled={busy || !plotter}
+            onClick={() => moveAbs('Min X', 'X', 0)}
+          >
+            Min X
+          </Button>
+          <Button
+            size="small"
+            variant="outlined"
+            disabled={busy || !plotter}
+            onClick={() => moveAbs('Max X', 'X', plotter?.bedWidth ?? 0)}
+          >
+            Max X
+          </Button>
+          <Button
+            size="small"
+            variant="outlined"
+            disabled={busy || !plotter}
+            onClick={() => moveAbs('Min Y', 'Y', 0)}
+          >
+            Min Y
+          </Button>
+          <Button
+            size="small"
+            variant="outlined"
+            disabled={busy || !plotter}
+            onClick={() => moveAbs('Max Y', 'Y', plotter?.bedHeight ?? 0)}
+          >
+            Max Y
+          </Button>
+        </Box>
+
+        <Divider sx={{ my: 2 }} />
+
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <TextField
+            size="small"
+            fullWidth
+            placeholder="Raw G-code, e.g. M115"
+            value={raw}
+            onChange={(e) => setRaw(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && raw.trim()) send('Send', raw.trim());
+            }}
+          />
+          <Button
+            size="small"
+            variant="outlined"
+            disabled={busy || !raw.trim()}
+            onClick={() => send('Send', raw.trim())}
+          >
+            Send
+          </Button>
+        </Box>
+
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ display: 'block', mt: 2, fontFamily: 'ui-monospace, Menlo, monospace' }}
+        >
+          {last || 'No commands sent yet.'}
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/paint-app/src/components/LayersPanel.tsx
+++ b/paint-app/src/components/LayersPanel.tsx
@@ -1,0 +1,148 @@
+import AddIcon from '@mui/icons-material/Add';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+import { Box, Button, IconButton, InputBase, TextField, Tooltip, Typography } from '@mui/material';
+import { Reorder } from 'framer-motion';
+import { useStore } from '../store';
+import type { Layer } from '../types';
+
+export const LayersPanel = () => {
+  const { state, addLayer, removeLayer, setActiveLayer, updateLayer, reorderLayers } = useStore();
+  const { layers, activeLayerId } = state;
+
+  // Reorder renders top-to-bottom; we display top of stack first (last in array reversed).
+  const orderedTopFirst = [...layers].reverse();
+
+  const onReorder = (next: Layer[]) => {
+    reorderLayers(
+      next
+        .slice()
+        .reverse()
+        .map((l) => l.id),
+    );
+  };
+
+  return (
+    <Box
+      sx={{
+        width: 240,
+        borderRight: '1px solid',
+        borderColor: 'divider',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <Box
+        sx={{
+          px: 1.5,
+          py: 1,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Typography variant="overline" color="text.secondary">
+          Layers
+        </Typography>
+        <Button size="small" startIcon={<AddIcon />} onClick={addLayer}>
+          Add
+        </Button>
+      </Box>
+      <Reorder.Group
+        axis="y"
+        values={orderedTopFirst}
+        onReorder={onReorder}
+        style={{ listStyle: 'none', margin: 0, padding: 0, flex: 1, overflowY: 'auto' }}
+      >
+        {orderedTopFirst.map((layer) => {
+          const isActive = layer.id === activeLayerId;
+          return (
+            <Reorder.Item
+              key={layer.id}
+              value={layer}
+              style={{
+                padding: 10,
+                borderBottom: '1px solid #eee',
+                background: isActive ? '#eef6ff' : '#fff',
+                cursor: 'grab',
+              }}
+              onPointerDown={() => setActiveLayer(layer.id)}
+            >
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+                <input
+                  type="color"
+                  value={layer.color}
+                  onChange={(e) => updateLayer(layer.id, { color: e.target.value })}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  style={{
+                    width: 22,
+                    height: 22,
+                    border: 'none',
+                    padding: 0,
+                    background: 'none',
+                    cursor: 'pointer',
+                  }}
+                />
+                <InputBase
+                  value={layer.name}
+                  onChange={(e) => updateLayer(layer.id, { name: e.target.value })}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  sx={{ flex: 1, fontWeight: 600, fontSize: 14 }}
+                />
+                <Tooltip title={layer.visible ? 'Hide' : 'Show'}>
+                  <IconButton
+                    size="small"
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      updateLayer(layer.id, { visible: !layer.visible });
+                    }}
+                  >
+                    {layer.visible ? (
+                      <VisibilityIcon fontSize="small" />
+                    ) : (
+                      <VisibilityOffIcon fontSize="small" />
+                    )}
+                  </IconButton>
+                </Tooltip>
+              </Box>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Typography variant="caption" color="text.secondary">
+                  thickness
+                </Typography>
+                <TextField
+                  type="number"
+                  size="small"
+                  value={layer.thickness}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onChange={(e) =>
+                    updateLayer(layer.id, { thickness: Number.parseFloat(e.target.value) || 0.1 })
+                  }
+                  slotProps={{
+                    htmlInput: { step: 0.1, min: 0.1, style: { padding: 4, width: 50 } },
+                  }}
+                />
+                <Typography variant="caption" color="text.secondary">
+                  mm
+                </Typography>
+                <Box sx={{ flex: 1 }} />
+                <IconButton
+                  size="small"
+                  color="error"
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (confirm(`Delete ${layer.name}?`)) removeLayer(layer.id);
+                  }}
+                >
+                  <DeleteOutlineIcon fontSize="small" />
+                </IconButton>
+              </Box>
+            </Reorder.Item>
+          );
+        })}
+      </Reorder.Group>
+    </Box>
+  );
+};

--- a/paint-app/src/components/PlotterCalibration.tsx
+++ b/paint-app/src/components/PlotterCalibration.tsx
@@ -1,0 +1,457 @@
+import HomeIcon from '@mui/icons-material/Home';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  IconButton,
+  MenuItem,
+  Select,
+  Stack,
+  Step,
+  StepLabel,
+  Stepper,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useState } from 'react';
+import { useConnection } from '../connection';
+import { type PlotterDraft, usePlotters } from '../plotters';
+
+type StepKind = 'corner-bl' | 'corner-tr' | 'penDownZ' | 'penUpZ';
+
+type Captured = {
+  blX?: number;
+  blY?: number;
+  trX?: number;
+  trY?: number;
+  penDownZ?: number;
+  penUpZ?: number;
+};
+
+type CalStep = {
+  kind: StepKind;
+  title: string;
+  description: string;
+};
+
+const STEPS: CalStep[] = [
+  {
+    kind: 'corner-bl',
+    title: 'Bottom-left',
+    description:
+      'Jog the head to the BOTTOM-LEFT corner of the drawing area as it should appear on paper, then capture.',
+  },
+  {
+    kind: 'corner-tr',
+    title: 'Top-right',
+    description:
+      'Jog the head to the TOP-RIGHT corner of the drawing area, then capture. The two corners define size and orientation (X/Y direction).',
+  },
+  {
+    kind: 'penDownZ',
+    title: 'Pen down',
+    description: 'Lower Z until the pen just touches the paper. This is the drawing height.',
+  },
+  {
+    kind: 'penUpZ',
+    title: 'Pen up',
+    description: 'Raise Z so the pen safely clears the paper for travel moves.',
+  },
+];
+
+const captureLabel = (c: Captured, kind: StepKind): string => {
+  const f = (n?: number) => (n === undefined ? '—' : n.toFixed(2));
+  switch (kind) {
+    case 'corner-bl':
+      return `${f(c.blX)}, ${f(c.blY)}`;
+    case 'corner-tr':
+      return `${f(c.trX)}, ${f(c.trY)}`;
+    case 'penDownZ':
+      return f(c.penDownZ);
+    case 'penUpZ':
+      return f(c.penUpZ);
+  }
+};
+
+const STEP_OPTIONS = [0.1, 1, 10];
+
+type Props = { onCreated: () => void };
+
+export const PlotterCalibration = ({ onCreated }: Props) => {
+  const { connection, connected, connect } = useConnection();
+  const { createPlotter } = usePlotters();
+
+  const [stepIdx, setStepIdx] = useState(0);
+  const [jogMm, setJogMm] = useState(10);
+  const [busy, setBusy] = useState(false);
+  const [position, setPosition] = useState<{ x: number; y: number; z: number } | null>(null);
+  const [captured, setCaptured] = useState<Captured>({});
+
+  // Final-form fields (not capturable by jogging)
+  const [name, setName] = useState('');
+  const [travelFeed, setTravelFeed] = useState(6000);
+  const [drawFeed, setDrawFeed] = useState(3000);
+
+  const onLastStep = stepIdx >= STEPS.length;
+  const step = STEPS[Math.min(stepIdx, STEPS.length - 1)];
+
+  const allCaptured = [
+    captured.blX,
+    captured.blY,
+    captured.trX,
+    captured.trY,
+    captured.penDownZ,
+    captured.penUpZ,
+  ].every((v) => v !== undefined);
+
+  const refreshPosition = async () => {
+    if (!connected) return;
+    setBusy(true);
+    try {
+      const p = await connection.getPosition();
+      if (p) setPosition(p);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const jog = async (axis: 'X' | 'Y' | 'Z', delta: number) => {
+    if (!connected) return;
+    setBusy(true);
+    try {
+      await connection.send('G91');
+      await connection.send(`G1 ${axis}${delta} F${travelFeed}`);
+      await connection.send('G90');
+      const p = await connection.getPosition();
+      if (p) setPosition(p);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const home = async () => {
+    if (!connected) return;
+    setBusy(true);
+    try {
+      await connection.send('G28');
+      const p = await connection.getPosition();
+      if (p) setPosition(p);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const capture = async () => {
+    if (!connected) return;
+    setBusy(true);
+    try {
+      const p = (await connection.getPosition()) ?? position;
+      if (!p) return;
+      setPosition(p);
+      setCaptured((prev) => {
+        switch (step.kind) {
+          case 'corner-bl':
+            return { ...prev, blX: p.x, blY: p.y };
+          case 'corner-tr':
+            return { ...prev, trX: p.x, trY: p.y };
+          case 'penDownZ':
+            return { ...prev, penDownZ: p.z };
+          case 'penUpZ':
+            return { ...prev, penUpZ: p.z };
+        }
+      });
+      setStepIdx((idx) => idx + 1);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const restart = () => {
+    setCaptured({});
+    setStepIdx(0);
+  };
+
+  const onSave = async () => {
+    if (!allCaptured || !name.trim()) return;
+    const blX = captured.blX ?? 0;
+    const blY = captured.blY ?? 0;
+    const trX = captured.trX ?? 0;
+    const trY = captured.trY ?? 0;
+    // Drawing-local origin is the page top-left with +y pointing down.
+    // Left edge = bottom-left's X; top edge = top-right's Y. The ±1
+    // directions absorb a machine whose X and/or Y runs backwards.
+    const dirX: 1 | -1 = trX >= blX ? 1 : -1;
+    const dirY: 1 | -1 = blY >= trY ? 1 : -1;
+    const draft: PlotterDraft = {
+      name: name.trim(),
+      bedWidth: Math.abs(trX - blX),
+      bedHeight: Math.abs(blY - trY),
+      travelFeed,
+      drawFeed,
+      penUpZ: captured.penUpZ ?? 5,
+      penDownZ: captured.penDownZ ?? 0,
+      originX: blX,
+      originY: trY,
+      dirX,
+      dirY,
+    };
+    await createPlotter(draft);
+    setName('');
+    setCaptured({});
+    setStepIdx(0);
+    onCreated();
+  };
+
+  return (
+    <Stack spacing={2}>
+      {!connected && (
+        <Alert
+          severity="warning"
+          action={
+            <Button size="small" onClick={connect}>
+              Connect
+            </Button>
+          }
+        >
+          Connect to the plotter to calibrate.
+        </Alert>
+      )}
+
+      <Stepper activeStep={onLastStep ? STEPS.length : stepIdx} alternativeLabel>
+        {STEPS.map((s) => (
+          <Step key={s.field}>
+            <StepLabel>{s.title}</StepLabel>
+          </Step>
+        ))}
+        <Step>
+          <StepLabel>Save</StepLabel>
+        </Step>
+      </Stepper>
+
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 2,
+          alignItems: 'flex-start',
+          flexDirection: { xs: 'column', sm: 'row' },
+        }}
+      >
+        <JogPad
+          disabled={!connected || busy}
+          jogMm={jogMm}
+          setJogMm={setJogMm}
+          onJog={jog}
+          onHome={home}
+          onReadPosition={refreshPosition}
+          position={position}
+        />
+
+        <Box sx={{ flex: 1 }}>
+          {!onLastStep ? (
+            <>
+              <Typography variant="subtitle2" gutterBottom>
+                Step {stepIdx + 1} of {STEPS.length}: {step.title}
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                {step.description}
+              </Typography>
+              <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
+                <Button variant="contained" onClick={capture} disabled={!connected || busy}>
+                  {step.kind.startsWith('corner') ? 'Capture corner' : 'Capture Z'}
+                </Button>
+                {stepIdx > 0 && (
+                  <Button onClick={() => setStepIdx((i) => Math.max(0, i - 1))} disabled={busy}>
+                    Back
+                  </Button>
+                )}
+              </Stack>
+            </>
+          ) : (
+            <>
+              <Typography variant="subtitle2" gutterBottom>
+                Review and save
+              </Typography>
+              <Stack spacing={1.5}>
+                <TextField
+                  label="Plotter name"
+                  size="small"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  autoFocus
+                />
+                <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1.5 }}>
+                  <TextField
+                    label="Travel feed (mm/min)"
+                    size="small"
+                    type="number"
+                    value={travelFeed}
+                    onChange={(e) => setTravelFeed(Number.parseFloat(e.target.value) || 0)}
+                  />
+                  <TextField
+                    label="Draw feed (mm/min)"
+                    size="small"
+                    type="number"
+                    value={drawFeed}
+                    onChange={(e) => setDrawFeed(Number.parseFloat(e.target.value) || 0)}
+                  />
+                </Box>
+                <Stack direction="row" spacing={1}>
+                  <Button onClick={restart}>Recalibrate</Button>
+                  <Box sx={{ flex: 1 }} />
+                  <Button variant="contained" onClick={onSave} disabled={!name.trim()}>
+                    Save plotter
+                  </Button>
+                </Stack>
+              </Stack>
+            </>
+          )}
+
+          <Box sx={{ mt: 2 }}>
+            <Typography variant="overline" color="text.secondary">
+              Captured
+            </Typography>
+            <Stack direction="row" spacing={1} sx={{ mt: 0.5, gap: 1, flexWrap: 'wrap' }}>
+              {STEPS.map((s) => {
+                const label = captureLabel(captured, s.kind);
+                const done = !label.includes('—');
+                return (
+                  <Chip
+                    key={s.kind}
+                    size="small"
+                    label={`${s.title}: ${label}`}
+                    variant={done ? 'filled' : 'outlined'}
+                    color={done ? 'primary' : 'default'}
+                  />
+                );
+              })}
+            </Stack>
+          </Box>
+        </Box>
+      </Box>
+    </Stack>
+  );
+};
+
+const JogPad = ({
+  disabled,
+  jogMm,
+  setJogMm,
+  onJog,
+  onHome,
+  onReadPosition,
+  position,
+}: {
+  disabled: boolean;
+  jogMm: number;
+  setJogMm: (n: number) => void;
+  onJog: (axis: 'X' | 'Y' | 'Z', delta: number) => void;
+  onHome: () => void;
+  onReadPosition: () => void;
+  position: { x: number; y: number; z: number } | null;
+}) => {
+  return (
+    <Box
+      sx={{
+        p: 1.5,
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 1,
+        minWidth: 240,
+      }}
+    >
+      <Stack direction="row" spacing={1} sx={{ alignItems: 'center', mb: 1 }}>
+        <Typography variant="caption" color="text.secondary">
+          step
+        </Typography>
+        <Select
+          size="small"
+          value={jogMm}
+          onChange={(e) => setJogMm(Number(e.target.value))}
+          sx={{ minWidth: 80 }}
+        >
+          {STEP_OPTIONS.map((s) => (
+            <MenuItem key={s} value={s}>
+              {s} mm
+            </MenuItem>
+          ))}
+        </Select>
+        <Box sx={{ flex: 1 }} />
+        <IconButton size="small" onClick={onHome} disabled={disabled} title="Home (G28)">
+          <HomeIcon fontSize="small" />
+        </IconButton>
+      </Stack>
+
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: '40px 40px 40px 1fr 40px',
+          gridTemplateRows: '40px 40px 40px',
+          gap: 0.5,
+          alignItems: 'center',
+          justifyContent: 'start',
+        }}
+      >
+        <Box />
+        <IconButton disabled={disabled} onClick={() => onJog('Y', -jogMm)} title="Y -" size="small">
+          <KeyboardArrowUpIcon />
+        </IconButton>
+        <Box />
+        <Box />
+        <Button
+          disabled={disabled}
+          size="small"
+          variant="outlined"
+          onClick={() => onJog('Z', jogMm)}
+          sx={{ minWidth: 0, gridRow: 1, gridColumn: 5 }}
+        >
+          Z+
+        </Button>
+
+        <IconButton disabled={disabled} onClick={() => onJog('X', -jogMm)} title="X -" size="small">
+          <KeyboardArrowLeftIcon />
+        </IconButton>
+        <Button
+          disabled={disabled}
+          size="small"
+          variant="outlined"
+          onClick={onReadPosition}
+          sx={{ minWidth: 0 }}
+        >
+          ?
+        </Button>
+        <IconButton disabled={disabled} onClick={() => onJog('X', jogMm)} title="X +" size="small">
+          <KeyboardArrowRightIcon />
+        </IconButton>
+        <Box />
+        <Box />
+
+        <Box />
+        <IconButton disabled={disabled} onClick={() => onJog('Y', jogMm)} title="Y +" size="small">
+          <KeyboardArrowDownIcon />
+        </IconButton>
+        <Box />
+        <Box />
+        <Button
+          disabled={disabled}
+          size="small"
+          variant="outlined"
+          onClick={() => onJog('Z', -jogMm)}
+          sx={{ minWidth: 0, gridRow: 3, gridColumn: 5 }}
+        >
+          Z−
+        </Button>
+      </Box>
+
+      <Box sx={{ mt: 1.5, fontFamily: 'ui-monospace, Menlo, monospace', fontSize: 12 }}>
+        {position
+          ? `X ${position.x.toFixed(2)}  Y ${position.y.toFixed(2)}  Z ${position.z.toFixed(2)}`
+          : 'position —'}
+      </Box>
+    </Box>
+  );
+};

--- a/paint-app/src/components/PlotterCalibration.tsx
+++ b/paint-app/src/components/PlotterCalibration.tsx
@@ -224,7 +224,7 @@ export const PlotterCalibration = ({ onCreated }: Props) => {
 
       <Stepper activeStep={onLastStep ? STEPS.length : stepIdx} alternativeLabel>
         {STEPS.map((s) => (
-          <Step key={s.field}>
+          <Step key={s.kind}>
             <StepLabel>{s.title}</StepLabel>
           </Step>
         ))}

--- a/paint-app/src/components/PlottersModal.tsx
+++ b/paint-app/src/components/PlottersModal.tsx
@@ -1,0 +1,324 @@
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
+import EditIcon from '@mui/icons-material/Edit';
+import TuneIcon from '@mui/icons-material/Tune';
+import {
+  Alert,
+  Box,
+  Button,
+  ButtonBase,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useEffect, useState } from 'react';
+import { db } from '../db';
+import { type PlotterDraft, usePlotters } from '../plotters';
+import { PlotterCalibration } from './PlotterCalibration';
+
+const EMPTY_DRAFT: PlotterDraft = {
+  name: '',
+  bedWidth: 220,
+  bedHeight: 220,
+  travelFeed: 6000,
+  drawFeed: 3000,
+  penUpZ: 5,
+  penDownZ: 0,
+};
+
+type Mode = 'manual' | 'calibrate' | null;
+
+type Props = { open: boolean; onClose: () => void };
+
+export const PlottersModal = ({ open, onClose }: Props) => {
+  const { plotters, createPlotter, updatePlotter, deletePlotter } = usePlotters();
+  const [draft, setDraft] = useState<PlotterDraft>(EMPTY_DRAFT);
+  const [mode, setMode] = useState<Mode>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [usageById, setUsageById] = useState<Record<string, number>>({});
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (async () => {
+      const all = await db.projects.toArray();
+      const counts: Record<string, number> = {};
+      for (const p of all) {
+        const id = p.state.plotterId;
+        if (!id) continue;
+        counts[id] = (counts[id] ?? 0) + 1;
+      }
+      if (!cancelled) setUsageById(counts);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const onSubmit = async () => {
+    if (!draft.name.trim()) return;
+    const clean = { ...draft, name: draft.name.trim() };
+    if (editingId) {
+      await updatePlotter(editingId, clean);
+    } else {
+      await createPlotter(clean);
+    }
+    setDraft(EMPTY_DRAFT);
+    setEditingId(null);
+    setMode(null);
+  };
+
+  const onEdit = (id: string) => {
+    const p = plotters.find((x) => x.id === id);
+    if (!p) return;
+    const { id: _id, createdAt: _createdAt, ...rest } = p;
+    setDraft(rest);
+    setEditingId(id);
+    setMode('manual');
+  };
+
+  const onDelete = async (id: string) => {
+    const inUse = usageById[id] ?? 0;
+    if (inUse > 0) {
+      alert(
+        `This plotter is used by ${inUse} project${inUse === 1 ? '' : 's'} and can't be deleted.`,
+      );
+      return;
+    }
+    if (!confirm('Delete this plotter? This cannot be undone.')) return;
+    await deletePlotter(id);
+  };
+
+  const handleClose = () => {
+    setMode(null);
+    setEditingId(null);
+    setDraft(EMPTY_DRAFT);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} fullWidth maxWidth="md">
+      <DialogTitle>Plotters</DialogTitle>
+      <DialogContent dividers>
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          Projects reference a plotter by id. Editing one changes every project that uses it the
+          next time it builds G-code — create a separate plotter instead if you only want the change
+          for a new project.
+        </Alert>
+
+        <Typography variant="subtitle2" gutterBottom>
+          Existing plotters
+        </Typography>
+        {plotters.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            None yet.
+          </Typography>
+        ) : (
+          <List dense disablePadding>
+            {plotters.map((p) => {
+              const usage = usageById[p.id] ?? 0;
+              return (
+                <ListItem
+                  key={p.id}
+                  disableGutters
+                  secondaryAction={
+                    <Stack direction="row" spacing={0.5}>
+                      <IconButton edge="end" size="small" onClick={() => onEdit(p.id)} title="Edit">
+                        <EditIcon fontSize="small" />
+                      </IconButton>
+                      <IconButton
+                        edge="end"
+                        size="small"
+                        onClick={() => onDelete(p.id)}
+                        disabled={usage > 0}
+                        title={
+                          usage > 0 ? `Used by ${usage} project${usage === 1 ? '' : 's'}` : 'Delete'
+                        }
+                      >
+                        <DeleteOutlineIcon fontSize="small" />
+                      </IconButton>
+                    </Stack>
+                  }
+                >
+                  <ListItemText
+                    primary={p.name}
+                    secondary={
+                      <>
+                        Bed {p.bedWidth}×{p.bedHeight}mm · travel {p.travelFeed} · draw {p.drawFeed}{' '}
+                        · Z up {p.penUpZ} / down {p.penDownZ}
+                        {usage > 0 && ` · used by ${usage} project${usage === 1 ? '' : 's'}`}
+                      </>
+                    }
+                  />
+                </ListItem>
+              );
+            })}
+          </List>
+        )}
+
+        <Divider sx={{ my: 3 }} />
+
+        <Typography variant="subtitle2" gutterBottom>
+          {editingId ? 'Edit plotter' : 'New plotter'}
+        </Typography>
+
+        {mode === null ? (
+          <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2 }}>
+            <MethodCard
+              icon={<EditIcon />}
+              title="Manual entry"
+              description="Type each value (bed size, feed rates, pen Z heights). Quick if you already know your machine's parameters."
+              onClick={() => setMode('manual')}
+            />
+            <MethodCard
+              icon={<TuneIcon />}
+              title="Calibrate"
+              description="Connect and jog to two corners (bottom-left, top-right) plus pen up/down. Captures bed size, pen Z, and X/Y orientation live via M114."
+              onClick={() => setMode('calibrate')}
+            />
+          </Box>
+        ) : (
+          <>
+            <Box sx={{ mb: 1.5 }}>
+              <Button
+                size="small"
+                startIcon={<ArrowBackIcon />}
+                onClick={() => {
+                  setMode(null);
+                  setEditingId(null);
+                  setDraft(EMPTY_DRAFT);
+                }}
+              >
+                {editingId
+                  ? 'Cancel edit'
+                  : `${mode === 'manual' ? 'Manual entry' : 'Calibrate'} · change method`}
+              </Button>
+            </Box>
+            {mode === 'manual' ? (
+              <Stack spacing={1.5}>
+                <TextField
+                  label="Name"
+                  size="small"
+                  value={draft.name}
+                  onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+                  autoFocus
+                />
+                <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1.5 }}>
+                  <NumField
+                    label="Bed width (mm)"
+                    value={draft.bedWidth}
+                    onChange={(v) => setDraft({ ...draft, bedWidth: v })}
+                  />
+                  <NumField
+                    label="Bed height (mm)"
+                    value={draft.bedHeight}
+                    onChange={(v) => setDraft({ ...draft, bedHeight: v })}
+                  />
+                  <NumField
+                    label="Travel feed (mm/min)"
+                    value={draft.travelFeed}
+                    onChange={(v) => setDraft({ ...draft, travelFeed: v })}
+                  />
+                  <NumField
+                    label="Draw feed (mm/min)"
+                    value={draft.drawFeed}
+                    onChange={(v) => setDraft({ ...draft, drawFeed: v })}
+                  />
+                  <NumField
+                    label="Pen up Z (mm)"
+                    value={draft.penUpZ}
+                    onChange={(v) => setDraft({ ...draft, penUpZ: v })}
+                  />
+                  <NumField
+                    label="Pen down Z (mm)"
+                    value={draft.penDownZ}
+                    onChange={(v) => setDraft({ ...draft, penDownZ: v })}
+                  />
+                </Box>
+              </Stack>
+            ) : (
+              <PlotterCalibration onCreated={() => setMode(null)} />
+            )}
+          </>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Close</Button>
+        {mode === 'manual' && (
+          <Button variant="contained" onClick={onSubmit} disabled={!draft.name.trim()}>
+            {editingId ? 'Save changes' : 'Create plotter'}
+          </Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+const MethodCard = ({
+  icon,
+  title,
+  description,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  onClick: () => void;
+}) => (
+  <ButtonBase
+    onClick={onClick}
+    sx={{ display: 'block', textAlign: 'left', borderRadius: 1, height: '100%' }}
+  >
+    <Paper
+      variant="outlined"
+      sx={{
+        p: 2,
+        height: '100%',
+        transition: 'border-color 0.15s, box-shadow 0.15s',
+        '&:hover': {
+          borderColor: 'primary.main',
+          boxShadow: 1,
+        },
+      }}
+    >
+      <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', mb: 1 }}>
+        <Box sx={{ color: 'primary.main', display: 'flex' }}>{icon}</Box>
+        <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+          {title}
+        </Typography>
+      </Stack>
+      <Typography variant="body2" color="text.secondary">
+        {description}
+      </Typography>
+    </Paper>
+  </ButtonBase>
+);
+
+const NumField = ({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+}) => (
+  <TextField
+    label={label}
+    size="small"
+    type="number"
+    value={value}
+    onChange={(e) => onChange(Number.parseFloat(e.target.value) || 0)}
+    slotProps={{ htmlInput: { step: 0.1 } }}
+  />
+);

--- a/paint-app/src/components/PrintModal.tsx
+++ b/paint-app/src/components/PrintModal.tsx
@@ -1,0 +1,221 @@
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from '@mui/material';
+import { useEffect, useRef, useState } from 'react';
+import { useConnection } from '../connection';
+import { buildLayerPrograms, EPILOGUE, PROLOGUE } from '../gcode';
+import { usePlotters } from '../plotters';
+import { useStore } from '../store';
+
+type Props = {
+  onClose: () => void;
+};
+
+type Phase =
+  | { kind: 'idle' }
+  | { kind: 'running'; layerIdx: number; layerName: string; color: string }
+  | { kind: 'paused'; nextLayerIdx: number; nextLayerName: string; nextColor: string }
+  | { kind: 'done' }
+  | { kind: 'error'; message: string };
+
+export const PrintModal = ({ onClose }: Props) => {
+  const { state } = useStore();
+  const { getPlotter } = usePlotters();
+  const { connection } = useConnection();
+  const { pages, layers, activePageId, plotterId } = state;
+  const activePage = pages.find((p) => p.id === activePageId);
+  const plotter = getPlotter(plotterId) ?? null;
+  const programs = activePage && plotter ? buildLayerPrograms(layers, activePage, plotter) : [];
+
+  const [phase, setPhase] = useState<Phase>({ kind: 'idle' });
+  const cancelled = useRef(false);
+  const resumeRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    return () => {
+      cancelled.current = true;
+      resumeRef.current?.();
+    };
+  }, []);
+
+  const playChime = () => {
+    try {
+      const ctx = new (
+        window.AudioContext ||
+        (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
+      )();
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.frequency.value = 880;
+      gain.gain.setValueAtTime(0.0001, ctx.currentTime);
+      gain.gain.exponentialRampToValueAtTime(0.2, ctx.currentTime + 0.02);
+      gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.6);
+      osc.start();
+      osc.stop(ctx.currentTime + 0.6);
+    } catch {}
+  };
+
+  const start = async () => {
+    if (!plotter) {
+      setPhase({ kind: 'error', message: 'No plotter selected for this project.' });
+      return;
+    }
+    if (!activePage || programs.length === 0) {
+      setPhase({ kind: 'error', message: 'Nothing to print on the active page.' });
+      return;
+    }
+    cancelled.current = false;
+    try {
+      await connection.sendMany(PROLOGUE(plotter));
+      for (let i = 0; i < programs.length; i++) {
+        if (cancelled.current) return;
+        const program = programs[i];
+        setPhase({
+          kind: 'running',
+          layerIdx: i,
+          layerName: program.layerName,
+          color: program.color,
+        });
+        await connection.sendMany(program.lines);
+        if (cancelled.current) return;
+        if (i < programs.length - 1) {
+          const next = programs[i + 1];
+          playChime();
+          setPhase({
+            kind: 'paused',
+            nextLayerIdx: i + 1,
+            nextLayerName: next.layerName,
+            nextColor: next.color,
+          });
+          await new Promise<void>((resolve) => {
+            resumeRef.current = resolve;
+          });
+          resumeRef.current = null;
+          if (cancelled.current) return;
+        }
+      }
+      await connection.sendMany(EPILOGUE(plotter));
+      setPhase({ kind: 'done' });
+    } catch (e) {
+      setPhase({ kind: 'error', message: (e as Error).message });
+    }
+  };
+
+  return (
+    <Dialog open onClose={phase.kind === 'idle' ? onClose : undefined} fullWidth maxWidth="xs">
+      <DialogTitle>Print</DialogTitle>
+      <DialogContent dividers>
+        {phase.kind === 'idle' && (
+          <>
+            <Typography variant="body2" sx={{ mb: 1 }}>
+              Plotter: <strong>{plotter?.name ?? '— none —'}</strong>
+            </Typography>
+            <Typography variant="body2" sx={{ mb: 2 }}>
+              About to print <strong>{programs.length}</strong> visible layer
+              {programs.length === 1 ? '' : 's'} on the active page.
+            </Typography>
+            {programs.map((p) => (
+              <Box key={p.layerId} sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.5 }}>
+                <Box
+                  sx={{
+                    width: 14,
+                    height: 14,
+                    borderRadius: '50%',
+                    background: p.color,
+                    border: '1px solid #ccc',
+                  }}
+                />
+                <Typography variant="body2">{p.layerName}</Typography>
+                <Box sx={{ flex: 1 }} />
+                <Typography variant="caption" color="text.secondary">
+                  {p.lines.length} lines
+                </Typography>
+              </Box>
+            ))}
+          </>
+        )}
+        {phase.kind === 'running' && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <CircularProgress size={16} />
+            <Typography>
+              Printing <strong>{phase.layerName}</strong>
+            </Typography>
+            <Box
+              sx={{
+                width: 14,
+                height: 14,
+                borderRadius: '50%',
+                background: phase.color,
+                border: '1px solid #ccc',
+              }}
+            />
+          </Box>
+        )}
+        {phase.kind === 'paused' && (
+          <>
+            <Typography variant="h6">Swap pen</Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1 }}>
+              <Typography>
+                Insert pen for <strong>{phase.nextLayerName}</strong>
+              </Typography>
+              <Box
+                sx={{
+                  width: 14,
+                  height: 14,
+                  borderRadius: '50%',
+                  background: phase.nextColor,
+                  border: '1px solid #ccc',
+                }}
+              />
+            </Box>
+          </>
+        )}
+        {phase.kind === 'done' && <Typography>Done.</Typography>}
+        {phase.kind === 'error' && <Typography color="error">Error: {phase.message}</Typography>}
+      </DialogContent>
+      <DialogActions>
+        {phase.kind === 'idle' && (
+          <>
+            <Button onClick={onClose}>Cancel</Button>
+            <Button
+              variant="contained"
+              onClick={start}
+              disabled={programs.length === 0 || !plotter}
+            >
+              Start
+            </Button>
+          </>
+        )}
+        {phase.kind === 'paused' && (
+          <>
+            <Button
+              color="error"
+              onClick={() => {
+                cancelled.current = true;
+                resumeRef.current?.();
+                onClose();
+              }}
+            >
+              Abort
+            </Button>
+            <Button variant="contained" onClick={() => resumeRef.current?.()}>
+              Resume
+            </Button>
+          </>
+        )}
+        {(phase.kind === 'done' || phase.kind === 'error') && (
+          <Button onClick={onClose}>Close</Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/paint-app/src/components/ProjectGate.tsx
+++ b/paint-app/src/components/ProjectGate.tsx
@@ -1,0 +1,363 @@
+import BoltIcon from '@mui/icons-material/Bolt';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
+import {
+  AppBar,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Divider,
+  FormControl,
+  IconButton,
+  InputLabel,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  MenuItem,
+  Toolbar as MuiToolbar,
+  Paper,
+  Select,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { useCallback, useEffect, useState } from 'react';
+import { useConnection } from '../connection';
+import { db, type Project } from '../db';
+import { type PlotterDraft, usePlotters } from '../plotters';
+import { INTERACTIVE_PROJECT_ID, useProject } from './../project';
+import { createInitialState } from '../store';
+import { type AppState, AppStateSchema, LegacyAppStateSchema } from '../types';
+import { PlottersModal } from './PlottersModal';
+import { SettingsMenu } from './SettingsMenu';
+
+const uid = () => Math.random().toString(36).slice(2, 10);
+
+/**
+ * Bring a stored AppState onto the current schema. Returns `[migratedState, plotterToCreate?]`
+ * where plotterToCreate is non-null if we had to fabricate a plotter from a
+ * legacy project's inline `settings` block.
+ */
+const migrateState = (raw: unknown): { state: AppState; plotterDraft?: PlotterDraft } | null => {
+  const direct = AppStateSchema.safeParse(raw);
+  if (direct.success) return { state: direct.data };
+  const legacy = LegacyAppStateSchema.safeParse(raw);
+  if (legacy.success) {
+    const tempPlotterId = uid();
+    return {
+      state: {
+        pages: legacy.data.pages,
+        layers: legacy.data.layers,
+        activePageId: legacy.data.activePageId,
+        activeLayerId: legacy.data.activeLayerId,
+        plotterId: tempPlotterId,
+      },
+      plotterDraft: {
+        name: 'Migrated plotter',
+        ...legacy.data.settings,
+      },
+    };
+  }
+  return null;
+};
+
+export const ProjectGate = () => {
+  const { setProject } = useProject();
+  const { plotters, ready: plottersReady, createPlotter } = usePlotters();
+  const {
+    connected,
+    connecting,
+    connectPhase,
+    connect,
+    disconnect,
+    connectError,
+    dismissConnectError,
+  } = useConnection();
+  const [projects, setProjects] = useState<Project[] | null>(null);
+  const [name, setName] = useState('');
+  const [pickedPlotterId, setPickedPlotterId] = useState<string>('');
+  const [plottersOpen, setPlottersOpen] = useState(false);
+
+  const refresh = useCallback(async () => {
+    const all = await db.projects.orderBy('updatedAt').reverse().toArray();
+    setProjects(all);
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // Default the new-project plotter selector to the most recent plotter.
+  useEffect(() => {
+    if (!pickedPlotterId && plotters.length > 0) {
+      setPickedPlotterId(plotters[plotters.length - 1].id);
+    }
+  }, [plotters, pickedPlotterId]);
+
+  const onCreate = async () => {
+    const trimmed = name.trim();
+    if (!trimmed || !pickedPlotterId) return;
+    const plotter = plotters.find((p) => p.id === pickedPlotterId);
+    if (!plotter) return;
+    const now = Date.now();
+    const project: Project = {
+      id: uid(),
+      name: trimmed,
+      state: createInitialState(plotter),
+      createdAt: now,
+      updatedAt: now,
+    };
+    await db.projects.put(project);
+    setProject({ id: project.id, name: project.name }, project.state);
+  };
+
+  const onOpen = async (id: string) => {
+    const project = await db.projects.get(id);
+    if (!project) return;
+    const migrated = migrateState(project.state);
+    if (!migrated) {
+      alert('This project has an unrecognised state shape and cannot be opened.');
+      return;
+    }
+    let { state } = migrated;
+    if (migrated.plotterDraft) {
+      const newPlotter = await createPlotter(migrated.plotterDraft);
+      state = { ...state, plotterId: newPlotter.id };
+    }
+    if (state !== project.state) {
+      await db.projects.update(id, { state });
+    }
+    setProject({ id: project.id, name: project.name }, state);
+  };
+
+  const onStartInteractive = async () => {
+    const plotter = plotters[plotters.length - 1];
+    if (!plotter) return;
+    // Interactive sessions are ephemeral. Wipe any leftover persisted record
+    // (from earlier app versions or aborted runs) and start in memory only.
+    await db.projects.delete(INTERACTIVE_PROJECT_ID).catch(() => {});
+    setProject(
+      { id: INTERACTIVE_PROJECT_ID, name: 'Interactive session' },
+      createInitialState(plotter),
+    );
+  };
+
+  const visibleProjects = (projects ?? []).filter((p) => p.id !== INTERACTIVE_PROJECT_ID);
+
+  const onDelete = async (id: string) => {
+    if (!confirm('Delete this project? This cannot be undone.')) return;
+    await db.projects.delete(id);
+    refresh();
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <AppBar position="static" color="default" elevation={1}>
+        <MuiToolbar variant="dense" sx={{ gap: 1 }}>
+          <SettingsMenu />
+          <Typography variant="subtitle1" sx={{ fontWeight: 600, ml: 1 }}>
+            paint-app
+          </Typography>
+        </MuiToolbar>
+      </AppBar>
+      <Box sx={{ flex: 1, overflow: 'auto', display: 'flex', justifyContent: 'center', p: 3 }}>
+        <Paper variant="outlined" sx={{ width: '100%', maxWidth: 600, p: 3 }}>
+          <Stack spacing={3}>
+            <Box>
+              {!plottersReady ? (
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <CircularProgress size={16} /> <span>Loading plotters…</span>
+                </Box>
+              ) : (
+                <Stack spacing={1}>
+                  <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                    {plotters.length === 0 ? (
+                      <Typography variant="body2" color="text.secondary" sx={{ flex: 1 }}>
+                        No plotters configured — define one before starting.
+                      </Typography>
+                    ) : (
+                      <FormControl size="small" sx={{ flex: 1 }}>
+                        <InputLabel>Plotter</InputLabel>
+                        <Select
+                          label="Plotter"
+                          value={pickedPlotterId}
+                          onChange={(e) => setPickedPlotterId(e.target.value)}
+                        >
+                          {plotters.map((p) => (
+                            <MenuItem key={p.id} value={p.id}>
+                              {p.name}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                    )}
+                    <Button
+                      size="small"
+                      variant={plotters.length === 0 ? 'contained' : 'text'}
+                      onClick={() => setPlottersOpen(true)}
+                    >
+                      {plotters.length === 0 ? 'Create plotter' : 'Manage…'}
+                    </Button>
+                    {connected ? (
+                      <Button size="small" color="error" onClick={disconnect}>
+                        Disconnect
+                      </Button>
+                    ) : (
+                      <Button
+                        size="small"
+                        variant={plotters.length === 0 ? 'outlined' : 'contained'}
+                        onClick={connect}
+                        disabled={connecting}
+                        startIcon={
+                          connecting ? <CircularProgress size={14} color="inherit" /> : null
+                        }
+                      >
+                        {connectPhase === 'homing'
+                          ? 'Homing…'
+                          : connectPhase === 'connecting'
+                            ? 'Connecting…'
+                            : 'Connect plotter'}
+                      </Button>
+                    )}
+                  </Stack>
+                  {connected && (
+                    <Typography variant="caption" color="success.main">
+                      Connected — homed and ready.
+                    </Typography>
+                  )}
+                </Stack>
+              )}
+            </Box>
+
+            <Divider />
+
+            <Tooltip
+              title={plotters.length === 0 ? 'Create a plotter first' : ''}
+              disableHoverListener={plotters.length > 0}
+              arrow
+            >
+              <Paper
+                variant="outlined"
+                sx={{
+                  p: 2,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1.5,
+                  borderColor: 'primary.main',
+                }}
+              >
+                <BoltIcon color="primary" />
+                <Box sx={{ flex: 1 }}>
+                  <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                    Interactive session
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    One live document — every stroke is sent to the plotter as soon as you draw it.
+                  </Typography>
+                </Box>
+                <Button
+                  variant="contained"
+                  onClick={onStartInteractive}
+                  disabled={plotters.length === 0 || !connected}
+                >
+                  Start
+                </Button>
+              </Paper>
+            </Tooltip>
+
+            <Divider />
+
+            <Box>
+              <Typography variant="subtitle2" gutterBottom>
+                Projects
+              </Typography>
+              {!plottersReady ? (
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <CircularProgress size={16} /> <span>Loading plotters…</span>
+                </Box>
+              ) : plotters.length === 0 ? (
+                <Typography variant="body2" color="text.secondary">
+                  Create a plotter above first.
+                </Typography>
+              ) : (
+                <Stack spacing={2}>
+                  <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                    <TextField
+                      size="small"
+                      fullWidth
+                      placeholder="New project name"
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
+                      onKeyDown={(e) => e.key === 'Enter' && onCreate()}
+                      autoFocus
+                    />
+                    <Button
+                      variant="contained"
+                      onClick={onCreate}
+                      disabled={!name.trim() || !pickedPlotterId || !connected}
+                    >
+                      Create
+                    </Button>
+                  </Stack>
+                  {projects === null ? (
+                    <Typography variant="body2" color="text.secondary">
+                      Loading…
+                    </Typography>
+                  ) : visibleProjects.length === 0 ? (
+                    <Typography variant="body2" color="text.secondary">
+                      No saved projects yet.
+                    </Typography>
+                  ) : (
+                    <List dense disablePadding>
+                      {visibleProjects.map((p) => (
+                        <ListItem
+                          key={p.id}
+                          disablePadding
+                          secondaryAction={
+                            <IconButton
+                              edge="end"
+                              size="small"
+                              aria-label="delete"
+                              onClick={() => onDelete(p.id)}
+                            >
+                              <DeleteOutlineIcon fontSize="small" />
+                            </IconButton>
+                          }
+                        >
+                          <ListItemButton onClick={() => onOpen(p.id)} disabled={!connected}>
+                            <ListItemText
+                              primary={p.name}
+                              secondary={`Updated ${new Date(p.updatedAt).toLocaleString()}`}
+                            />
+                          </ListItemButton>
+                        </ListItem>
+                      ))}
+                    </List>
+                  )}
+                </Stack>
+              )}
+            </Box>
+          </Stack>
+        </Paper>
+      </Box>
+
+      <PlottersModal open={plottersOpen} onClose={() => setPlottersOpen(false)} />
+
+      <Dialog open={connectError !== null} onClose={dismissConnectError}>
+        <DialogTitle sx={{ color: 'error.main' }}>Connection failed</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{connectError}</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={dismissConnectError}>Close</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};

--- a/paint-app/src/components/ScriptDialog.tsx
+++ b/paint-app/src/components/ScriptDialog.tsx
@@ -1,0 +1,182 @@
+import CheckIcon from '@mui/icons-material/Check';
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useEffect, useState } from 'react';
+import { createDrawAPI, runScript } from '../script-api';
+import { useStore } from '../store';
+import type { Point } from '../types';
+import { useUI } from '../ui';
+
+const STORAGE_KEY = 'paint-app:script';
+const PREVIEW_DEBOUNCE_MS = 250;
+
+const SAMPLE = `// page-local mm; (0,0) is top-left of the active page.
+// loops, math, variables — all standard JS.
+
+repeat(8, (i) => {
+  const r = 10 + i * 8;
+  circle(80, 80, r);
+});
+
+for (let i = 0; i < 5; i++) {
+  square(10 + i * 12, 10, 10);
+}
+
+// rect(x, y, w, h)        // square(x, y, size)
+// line(x1, y1, x2, y2)
+// ellipse(cx, cy, rx, ry)  // circle(cx, cy, r)
+// polygon(cx, cy, r, sides, rotation?)
+// star(cx, cy, r, points)
+// path([{x, y}, ...])      // repeat(n, fn)
+`;
+
+const REFERENCE = [
+  'rect(x, y, w, h)',
+  'square(x, y, size)',
+  'line(x1, y1, x2, y2)',
+  'ellipse(cx, cy, rx, ry)',
+  'circle(cx, cy, r)',
+  'polygon(cx, cy, r, sides, rotation?)',
+  'star(cx, cy, r, points)',
+  'path([{x, y}, ...])',
+  'repeat(n, fn)',
+  '— Math, for, while, etc. all available',
+];
+
+type Props = { open: boolean; onClose: () => void };
+
+export const ScriptDialog = ({ open, onClose }: Props) => {
+  const { state, addStroke } = useStore();
+  const { drawColor, scriptPreview, setScriptPreview } = useUI();
+  const [code, setCode] = useState<string>(() => localStorage.getItem(STORAGE_KEY) ?? SAMPLE);
+  const [error, setError] = useState<string | null>(null);
+
+  const activeLayer = state.layers.find((l) => l.id === state.activeLayerId);
+  const activePage = state.pages.find((p) => p.id === state.activePageId);
+
+  // Recompute the preview after the user stops typing (debounced). On error
+  // we keep the previous preview so the canvas doesn't flicker mid-typo.
+  useEffect(() => {
+    if (!open || !activePage) return;
+    const handle = setTimeout(() => {
+      const collected: Point[][] = [];
+      const api = createDrawAPI(activePage, (points) => {
+        collected.push(points);
+      });
+      try {
+        runScript(code, api);
+        setScriptPreview(collected);
+        setError(null);
+      } catch (e) {
+        setError((e as Error).message);
+      }
+    }, PREVIEW_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [code, open, activePage, setScriptPreview]);
+
+  // Drop the preview when the dialog closes via any path.
+  useEffect(() => {
+    if (!open) setScriptPreview(null);
+  }, [open, setScriptPreview]);
+
+  const onCancel = () => {
+    setScriptPreview(null);
+    onClose();
+  };
+
+  const onCommit = () => {
+    if (!activeLayer) {
+      setError('No active layer.');
+      return;
+    }
+    if (!scriptPreview) return;
+    for (const points of scriptPreview) {
+      addStroke(activeLayer.id, points, drawColor);
+    }
+    localStorage.setItem(STORAGE_KEY, code);
+    setScriptPreview(null);
+    onClose();
+  };
+
+  const liveCount = scriptPreview?.length ?? 0;
+
+  return (
+    <Dialog open={open} onClose={onCancel} fullWidth maxWidth="md">
+      <DialogTitle>Script</DialogTitle>
+      <DialogContent dividers>
+        <Box sx={{ display: 'flex', gap: 2 }}>
+          <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <TextField
+              multiline
+              minRows={14}
+              maxRows={24}
+              fullWidth
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              slotProps={{
+                input: {
+                  sx: {
+                    fontFamily: 'ui-monospace, Menlo, monospace',
+                    fontSize: 13,
+                    lineHeight: 1.5,
+                  },
+                },
+              }}
+            />
+            {error ? (
+              <Alert severity="error">{error}</Alert>
+            ) : (
+              <Alert severity="info">
+                Preview: <strong>{liveCount}</strong> stroke{liveCount === 1 ? '' : 's'} (dashed
+                ghost on the canvas). Click OK to commit to{' '}
+                <strong>{activeLayer?.name ?? 'layer'}</strong>.
+              </Alert>
+            )}
+          </Box>
+          <Box sx={{ width: 220 }}>
+            <Typography variant="overline" color="text.secondary">
+              API
+            </Typography>
+            <Box
+              component="pre"
+              sx={{
+                m: 0,
+                fontFamily: 'ui-monospace, Menlo, monospace',
+                fontSize: 11,
+                lineHeight: 1.6,
+                color: 'text.secondary',
+                whiteSpace: 'pre-wrap',
+              }}
+            >
+              {REFERENCE.join('\n')}
+            </Box>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 2 }}>
+              Coordinates are mm, with (0, 0) at the top-left of the active page. The preview
+              re-renders ~{PREVIEW_DEBOUNCE_MS}ms after each keystroke.
+            </Typography>
+          </Box>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onCancel}>Cancel</Button>
+        <Button
+          variant="contained"
+          startIcon={<CheckIcon />}
+          onClick={onCommit}
+          disabled={!!error || liveCount === 0}
+        >
+          OK
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/paint-app/src/components/SettingsMenu.tsx
+++ b/paint-app/src/components/SettingsMenu.tsx
@@ -1,0 +1,435 @@
+import AddIcon from '@mui/icons-material/Add';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
+import DownloadIcon from '@mui/icons-material/Download';
+import EditIcon from '@mui/icons-material/Edit';
+import LogoutIcon from '@mui/icons-material/Logout';
+import PrintIcon from '@mui/icons-material/Print';
+import RemoveIcon from '@mui/icons-material/Remove';
+import SaveIcon from '@mui/icons-material/Save';
+import SettingsIcon from '@mui/icons-material/Settings';
+import TerminalIcon from '@mui/icons-material/Terminal';
+import UploadIcon from '@mui/icons-material/Upload';
+import {
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  TextField,
+  Tooltip,
+} from '@mui/material';
+import { type FC, useRef, useState } from 'react';
+import { useConnection } from '../connection';
+import { db, type Project } from '../db';
+import { usePlotters } from '../plotters';
+import { INTERACTIVE_PROJECT_ID, useProject } from '../project';
+import { useStore } from '../store';
+import { AppStateSchema, PlotterSchema } from '../types';
+import { GRID_SIZE_MAX, GRID_SIZE_MIN, useUI } from '../ui';
+import { PlottersModal } from './PlottersModal';
+
+const uid = () => Math.random().toString(36).slice(2, 10);
+
+/**
+ * Everything a menu item might need. The container builds one of these and
+ * passes it to every item; items pick what they use. Keeps item components
+ * pure and the MENUS config a plain list of component references.
+ */
+type MenuCtx = {
+  close: () => void;
+  isInteractive: boolean;
+  // view toggles
+  showGrid: boolean;
+  setShowGrid: (v: boolean) => void;
+  gridSize: number;
+  setGridSize: (n: number) => void;
+  showLog: boolean;
+  setShowLog: (v: boolean) => void;
+  // project file ops
+  autosave: boolean;
+  setAutosave: (v: boolean) => void;
+  isDirty: boolean;
+  isSaving: boolean;
+  statusHint: string | null;
+  saveNow: () => Promise<void>;
+  onExport: () => void;
+  openImport: () => void;
+  startRename: () => void;
+  onDelete: () => void;
+  onSwitch: () => void;
+  openPlotters: () => void;
+};
+
+type MenuItemComponent = FC<{ ctx: MenuCtx }>;
+
+// ─── Menu items ──────────────────────────────────────────────────────────
+// One functional component per item. Add a new item here, then list it in
+// MENUS below for whichever menus should render it.
+
+const AutosaveItem: MenuItemComponent = ({ ctx }) => (
+  <MenuItem onClick={() => ctx.setAutosave(!ctx.autosave)}>
+    <ListItemIcon>
+      <Checkbox edge="start" checked={ctx.autosave} disableRipple sx={{ p: 0 }} />
+    </ListItemIcon>
+    <ListItemText primary="Autosave" />
+  </MenuItem>
+);
+
+const ShowGridItem: MenuItemComponent = ({ ctx }) => (
+  <MenuItem onClick={() => ctx.setShowGrid(!ctx.showGrid)}>
+    <ListItemIcon>
+      <Checkbox edge="start" checked={ctx.showGrid} disableRipple sx={{ p: 0 }} />
+    </ListItemIcon>
+    <ListItemText primary="Show grid" />
+    <span style={{ display: 'flex', alignItems: 'center', gap: 4, marginLeft: 8 }}>
+      <Tooltip title="Smaller grid">
+        <span>
+          <IconButton
+            size="small"
+            disabled={ctx.gridSize <= GRID_SIZE_MIN}
+            onClick={(e) => {
+              e.stopPropagation();
+              ctx.setGridSize(ctx.gridSize - 1);
+            }}
+          >
+            <RemoveIcon fontSize="small" />
+          </IconButton>
+        </span>
+      </Tooltip>
+      <span style={{ minWidth: 36, textAlign: 'center', fontVariantNumeric: 'tabular-nums' }}>
+        {ctx.gridSize}mm
+      </span>
+      <Tooltip title="Larger grid">
+        <span>
+          <IconButton
+            size="small"
+            disabled={ctx.gridSize >= GRID_SIZE_MAX}
+            onClick={(e) => {
+              e.stopPropagation();
+              ctx.setGridSize(ctx.gridSize + 1);
+            }}
+          >
+            <AddIcon fontSize="small" />
+          </IconButton>
+        </span>
+      </Tooltip>
+    </span>
+  </MenuItem>
+);
+
+const ShowLogItem: MenuItemComponent = ({ ctx }) => (
+  <MenuItem onClick={() => ctx.setShowLog(!ctx.showLog)}>
+    <ListItemIcon>
+      <Checkbox edge="start" checked={ctx.showLog} disableRipple sx={{ p: 0 }} />
+    </ListItemIcon>
+    <ListItemText primary="Show log" />
+    <TerminalIcon fontSize="small" sx={{ ml: 1, color: 'text.disabled' }} />
+  </MenuItem>
+);
+
+const SaveNowItem: MenuItemComponent = ({ ctx }) => (
+  <MenuItem
+    onClick={async () => {
+      await ctx.saveNow();
+      ctx.close();
+    }}
+    disabled={!ctx.isDirty || ctx.isSaving}
+  >
+    <ListItemIcon>
+      <SaveIcon fontSize="small" />
+    </ListItemIcon>
+    <ListItemText primary="Save now" secondary={ctx.statusHint ?? undefined} />
+  </MenuItem>
+);
+
+const PlottersItem: MenuItemComponent = ({ ctx }) => (
+  <MenuItem onClick={ctx.openPlotters}>
+    <ListItemIcon>
+      <PrintIcon fontSize="small" />
+    </ListItemIcon>
+    <ListItemText primary="Plotters…" />
+  </MenuItem>
+);
+
+const ExportItem: MenuItemComponent = ({ ctx }) => (
+  <MenuItem onClick={ctx.onExport}>
+    <ListItemIcon>
+      <DownloadIcon fontSize="small" />
+    </ListItemIcon>
+    <ListItemText primary="Export project to file…" />
+  </MenuItem>
+);
+
+const ImportItem: MenuItemComponent = ({ ctx }) => (
+  <MenuItem onClick={ctx.openImport}>
+    <ListItemIcon>
+      <UploadIcon fontSize="small" />
+    </ListItemIcon>
+    <ListItemText primary="Import project from file…" />
+  </MenuItem>
+);
+
+const RenameItem: MenuItemComponent = ({ ctx }) => (
+  <MenuItem onClick={ctx.startRename}>
+    <ListItemIcon>
+      <EditIcon fontSize="small" />
+    </ListItemIcon>
+    <ListItemText primary="Rename project" />
+  </MenuItem>
+);
+
+const DeleteItem: MenuItemComponent = ({ ctx }) => (
+  <MenuItem onClick={ctx.onDelete}>
+    <ListItemIcon>
+      <DeleteOutlineIcon fontSize="small" color="error" />
+    </ListItemIcon>
+    <ListItemText primary="Delete project" />
+  </MenuItem>
+);
+
+const CloseItem: MenuItemComponent = ({ ctx }) => (
+  <MenuItem onClick={ctx.onSwitch}>
+    <ListItemIcon>
+      <LogoutIcon fontSize="small" />
+    </ListItemIcon>
+    <ListItemText primary={ctx.isInteractive ? 'Close' : 'Close / switch project'} />
+  </MenuItem>
+);
+
+// ─── Which items each menu renders ───────────────────────────────────────
+// Inner arrays are visual groups; a divider is drawn between groups. Edit
+// this table to change what shows up where.
+
+type MenuKind = 'home' | 'project' | 'interactive';
+
+const MENUS: Record<MenuKind, MenuItemComponent[][]> = {
+  home: [[ShowLogItem], [ImportItem]],
+  project: [
+    [AutosaveItem, ShowGridItem, ShowLogItem, SaveNowItem],
+    [PlottersItem],
+    [ExportItem, ImportItem],
+    [RenameItem, DeleteItem],
+    [CloseItem],
+  ],
+  interactive: [[ShowGridItem, ShowLogItem], [PlottersItem], [CloseItem]],
+};
+
+const itemKey = (Comp: MenuItemComponent) => Comp.displayName ?? Comp.name;
+
+// ─── Container ───────────────────────────────────────────────────────────
+
+export const SettingsMenu = () => {
+  const { state } = useStore();
+  const { ingestPlotter, getPlotter } = usePlotters();
+  const { showLog, setShowLog } = useConnection();
+  const { showGrid, setShowGrid, gridSize, setGridSize } = useUI();
+  const {
+    project,
+    autosave,
+    setAutosave,
+    saveNow,
+    isDirty,
+    isSaving,
+    closeProject,
+    renameProject,
+    deleteProject,
+    setProject,
+  } = useProject();
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+  const [renaming, setRenaming] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [plottersOpen, setPlottersOpen] = useState(false);
+  const importRef = useRef<HTMLInputElement | null>(null);
+
+  const open = Boolean(anchor);
+  const close = () => setAnchor(null);
+  const isInteractive = project?.id === INTERACTIVE_PROJECT_ID;
+  const menuKind: MenuKind = !project ? 'home' : isInteractive ? 'interactive' : 'project';
+
+  const onExport = () => {
+    if (!project) return;
+    const plotter = getPlotter(state.plotterId);
+    const payload = {
+      version: 2,
+      name: project.name,
+      state,
+      plotter: plotter ?? null,
+    };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${project.name.replace(/[^a-z0-9-_ ]/gi, '_')}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+    close();
+  };
+
+  const onImportFile = async (file: File) => {
+    try {
+      const text = await file.text();
+      const parsed = JSON.parse(text);
+      const importedState = AppStateSchema.parse(parsed?.state);
+
+      // If the export bundled a plotter snapshot, ingest it so the imported
+      // project's plotterId resolves locally.
+      const rawPlotter = parsed?.plotter;
+      if (rawPlotter) {
+        const plotterParsed = PlotterSchema.safeParse(rawPlotter);
+        if (plotterParsed.success) {
+          await ingestPlotter(plotterParsed.data);
+        }
+      }
+
+      const importedName: string =
+        typeof parsed?.name === 'string' && parsed.name.trim() ? parsed.name : file.name;
+      const now = Date.now();
+      const next: Project = {
+        id: uid(),
+        name: importedName,
+        state: importedState,
+        createdAt: now,
+        updatedAt: now,
+      };
+      await db.projects.put(next);
+      setProject({ id: next.id, name: next.name }, next.state);
+    } catch (e) {
+      alert(`Import failed: ${(e as Error).message}`);
+    }
+    close();
+  };
+
+  const startRename = () => {
+    if (!project) return;
+    setNewName(project.name);
+    setRenaming(true);
+    close();
+  };
+
+  const submitRename = async () => {
+    const trimmed = newName.trim();
+    if (!trimmed) return;
+    await renameProject(trimmed);
+    setRenaming(false);
+  };
+
+  const onDelete = async () => {
+    if (!project) return;
+    if (!confirm(`Delete "${project.name}"? This cannot be undone.`)) return;
+    await deleteProject();
+    close();
+  };
+
+  const onSwitch = async () => {
+    if (isDirty) {
+      if (!confirm('You have unsaved changes. Switch projects anyway?')) {
+        close();
+        return;
+      }
+    }
+    closeProject();
+    close();
+  };
+
+  const statusHint = !project
+    ? null
+    : isSaving
+      ? 'Saving…'
+      : isDirty
+        ? autosave
+          ? 'Saving soon'
+          : 'Unsaved changes'
+        : 'Saved';
+
+  const ctx: MenuCtx = {
+    close,
+    isInteractive,
+    showGrid,
+    setShowGrid,
+    gridSize,
+    setGridSize,
+    showLog,
+    setShowLog,
+    autosave,
+    setAutosave,
+    isDirty,
+    isSaving,
+    statusHint,
+    saveNow,
+    onExport,
+    openImport: () => importRef.current?.click(),
+    startRename,
+    onDelete,
+    onSwitch,
+    openPlotters: () => {
+      setPlottersOpen(true);
+      close();
+    },
+  };
+
+  const groups = MENUS[menuKind];
+
+  return (
+    <>
+      <Tooltip title={statusHint ?? 'Settings'}>
+        <IconButton color="inherit" onClick={(e) => setAnchor(e.currentTarget)} edge="start">
+          <SettingsIcon />
+        </IconButton>
+      </Tooltip>
+      <Menu anchorEl={anchor} open={open} onClose={close}>
+        {groups.flatMap((group, i) => {
+          const items = group.map((Comp) => <Comp key={itemKey(Comp)} ctx={ctx} />);
+          return i === 0
+            ? items
+            : [
+                // biome-ignore lint/suspicious/noArrayIndexKey: groups are a fixed, ordered list
+                <Divider key={`divider-${i}`} />,
+                ...items,
+              ];
+        })}
+      </Menu>
+
+      <input
+        ref={importRef}
+        type="file"
+        accept="application/json,.json"
+        hidden
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          if (f) onImportFile(f);
+          e.target.value = '';
+        }}
+      />
+
+      <Dialog open={renaming} onClose={() => setRenaming(false)}>
+        <DialogTitle>Rename project</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            fullWidth
+            size="small"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && submitRename()}
+            sx={{ mt: 1 }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setRenaming(false)}>Cancel</Button>
+          <Button onClick={submitRename} variant="contained" disabled={!newName.trim()}>
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <PlottersModal open={plottersOpen} onClose={() => setPlottersOpen(false)} />
+    </>
+  );
+};

--- a/paint-app/src/components/SettingsMenu.tsx
+++ b/paint-app/src/components/SettingsMenu.tsx
@@ -129,7 +129,7 @@ const ShowLogItem: MenuItemComponent = ({ ctx }) => (
     <ListItemIcon>
       <Checkbox edge="start" checked={ctx.showLog} disableRipple sx={{ p: 0 }} />
     </ListItemIcon>
-    <ListItemText primary="Show log" />
+    <ListItemText primary="Show logs" />
     <TerminalIcon fontSize="small" sx={{ ml: 1, color: 'text.disabled' }} />
   </MenuItem>
 );

--- a/paint-app/src/components/Toolbar.tsx
+++ b/paint-app/src/components/Toolbar.tsx
@@ -1,0 +1,169 @@
+import BoltIcon from '@mui/icons-material/Bolt';
+import BugReportIcon from '@mui/icons-material/BugReport';
+import DangerousIcon from '@mui/icons-material/Dangerous';
+import PauseIcon from '@mui/icons-material/Pause';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import PrintIcon from '@mui/icons-material/Print';
+import {
+  AppBar,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Toolbar as MuiToolbar,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { useState } from 'react';
+import { useConnection } from '../connection';
+import { INTERACTIVE_PROJECT_ID, useProject } from '../project';
+import { DebugModal } from './DebugModal';
+import { SettingsMenu } from './SettingsMenu';
+
+type Props = {
+  onPrint: () => void;
+};
+
+export const Toolbar = ({ onPrint }: Props) => {
+  const { project, isDirty, isSaving, autosave, closeProject } = useProject();
+  const {
+    connected,
+    paused,
+    pause,
+    resume,
+    emergencyStop,
+    emergencyStopped,
+    acknowledgeEmergencyStop,
+  } = useConnection();
+
+  const acknowledgeStop = () => {
+    acknowledgeEmergencyStop();
+    closeProject();
+  };
+  const [debugOpen, setDebugOpen] = useState(false);
+  const isInteractive = project?.id === INTERACTIVE_PROJECT_ID;
+
+  const status = isSaving ? 'saving…' : isDirty ? (autosave ? 'saving soon' : 'unsaved') : 'saved';
+
+  return (
+    <AppBar position="static" color="default" elevation={1}>
+      <MuiToolbar variant="dense" sx={{ gap: 1 }}>
+        <SettingsMenu />
+        <Typography variant="subtitle1" sx={{ fontWeight: 600, ml: 1 }}>
+          {project?.name ?? 'paint-app'}
+        </Typography>
+        {project && !isInteractive && (
+          <Box sx={{ ml: 1, display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            {isSaving && <CircularProgress size={12} />}
+            <Typography variant="caption" color="text.secondary">
+              {status}
+            </Typography>
+          </Box>
+        )}
+        <Box sx={{ flex: 1 }} />
+        {connected && (
+          <Tooltip
+            title={
+              paused
+                ? 'Resume — continue sending G-code'
+                : 'Pause — stop sending after the current move; the plotter holds position'
+            }
+          >
+            <Button
+              size="small"
+              color={paused ? 'success' : 'warning'}
+              variant="contained"
+              startIcon={paused ? <PlayArrowIcon /> : <PauseIcon />}
+              onClick={paused ? resume : pause}
+            >
+              {paused ? 'Resume' : 'Pause'}
+            </Button>
+          </Tooltip>
+        )}
+        {!isInteractive && (
+          <Button
+            size="small"
+            startIcon={<PrintIcon />}
+            variant="contained"
+            onClick={onPrint}
+            disabled={!connected}
+          >
+            Print
+          </Button>
+        )}
+        {connected && (
+          <Tooltip title="Manually test plotter movement and pen">
+            <Button
+              size="small"
+              startIcon={<BugReportIcon />}
+              variant="outlined"
+              onClick={() => setDebugOpen(true)}
+            >
+              Debug
+            </Button>
+          </Tooltip>
+        )}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          {isInteractive && (
+            <Tooltip
+              title={
+                connected
+                  ? 'Each new stroke is sent to the plotter immediately.'
+                  : 'Connect the plotter — strokes drawn while disconnected are not replayed.'
+              }
+            >
+              <Chip
+                icon={<BoltIcon />}
+                label={connected ? 'Connected' : 'Disconnected'}
+                color={connected ? 'success' : 'error'}
+                size="small"
+              />
+            </Tooltip>
+          )}
+        </Box>
+      </MuiToolbar>
+      {connected && (
+        <Tooltip title="Emergency stop — halts the plotter immediately (M112). Reconnect required afterward.">
+          <Button
+            color="error"
+            variant="contained"
+            startIcon={<DangerousIcon />}
+            onClick={emergencyStop}
+            sx={{
+              position: 'fixed',
+              bottom: 24,
+              right: 24,
+              zIndex: 2000,
+              fontWeight: 700,
+              boxShadow: 6,
+            }}
+          >
+            EMERGENCY STOP
+          </Button>
+        </Tooltip>
+      )}
+      {debugOpen && <DebugModal onClose={() => setDebugOpen(false)} />}
+      <Dialog open={emergencyStopped} onClose={acknowledgeStop}>
+        <DialogTitle sx={{ color: 'error.main' }}>Emergency stop triggered</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            The plotter received an emergency stop (M112) and its firmware is now halted. It will
+            not respond to any commands until you <strong>power cycle the 3D printer</strong> (turn
+            it off, wait a few seconds, then turn it back on).
+          </DialogContentText>
+          <DialogContentText sx={{ mt: 2 }}>
+            After power cycling, reconnect from the setup screen.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={acknowledgeStop}>Understood</Button>
+        </DialogActions>
+      </Dialog>
+    </AppBar>
+  );
+};

--- a/paint-app/src/components/Toolbar.tsx
+++ b/paint-app/src/components/Toolbar.tsx
@@ -1,6 +1,7 @@
 import BoltIcon from '@mui/icons-material/Bolt';
 import BugReportIcon from '@mui/icons-material/BugReport';
 import DangerousIcon from '@mui/icons-material/Dangerous';
+import GitHubIcon from '@mui/icons-material/GitHub';
 import PauseIcon from '@mui/icons-material/Pause';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import PrintIcon from '@mui/icons-material/Print';
@@ -15,6 +16,7 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
+  IconButton,
   Toolbar as MuiToolbar,
   Tooltip,
   Typography,
@@ -126,6 +128,18 @@ export const Toolbar = ({ onPrint }: Props) => {
             </Tooltip>
           )}
         </Box>
+        <Tooltip title="View on GitHub">
+          <IconButton
+            size="small"
+            component="a"
+            href="https://github.com/TravisBumgarner/gcode2dplotterart/tree/main/paint-app"
+            target="_blank"
+            rel="noopener noreferrer"
+            color="inherit"
+          >
+            <GitHubIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
       </MuiToolbar>
       {connected && (
         <Tooltip title="Emergency stop — halts the plotter immediately (M112). Reconnect required afterward.">

--- a/paint-app/src/connection.tsx
+++ b/paint-app/src/connection.tsx
@@ -1,0 +1,143 @@
+import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from 'react';
+import { type ConnectPhase, PlotterConnection } from './serial';
+
+const SHOW_LOG_LS_KEY = 'paint-app:showLog';
+
+type ConnectionCtx = {
+  connection: PlotterConnection;
+  connected: boolean;
+  connecting: boolean;
+  connectPhase: ConnectPhase | null;
+  connect: () => Promise<void>;
+  disconnect: () => Promise<void>;
+  /** Last connect failure message, surfaced as a modal. Null when none. */
+  connectError: string | null;
+  dismissConnectError: () => void;
+  /** Global pause: gates all G-code output (print + interactive). */
+  paused: boolean;
+  pause: () => void;
+  resume: () => void;
+  /** Fire M112 and tear down the (now-killed) connection. */
+  emergencyStop: () => Promise<void>;
+  /** True after an emergency stop until acknowledged; the board needs a
+   * power cycle before it will respond again. */
+  emergencyStopped: boolean;
+  acknowledgeEmergencyStop: () => void;
+  log: string[];
+  showLog: boolean;
+  setShowLog: (v: boolean) => void;
+};
+
+const ConnectionContext = createContext<ConnectionCtx | null>(null);
+
+export const ConnectionProvider = ({ children }: { children: ReactNode }) => {
+  const [connected, setConnected] = useState(false);
+  const [connectPhase, setConnectPhase] = useState<ConnectPhase | null>(null);
+  const [emergencyStopped, setEmergencyStopped] = useState(false);
+  const [connectError, setConnectError] = useState<string | null>(null);
+  const [paused, setPaused] = useState(false);
+  const [log, setLog] = useState<string[]>([]);
+  const [showLog, setShowLogState] = useState<boolean>(() => {
+    const raw = localStorage.getItem(SHOW_LOG_LS_KEY);
+    return raw === '1';
+  });
+
+  const setShowLog = useCallback((v: boolean) => {
+    setShowLogState(v);
+    localStorage.setItem(SHOW_LOG_LS_KEY, v ? '1' : '0');
+  }, []);
+
+  const connection = useMemo(
+    () =>
+      new PlotterConnection(
+        (line, kind) => {
+          const prefix = kind === 'tx' ? '> ' : kind === 'rx' ? '  ' : kind === 'err' ? '! ' : '· ';
+          const ts = (performance.now() / 1000).toFixed(3).padStart(8, ' ');
+          setLog((prev) => [...prev.slice(-200), `${ts}  ${prefix}${line}`]);
+        },
+        (phase) => setConnectPhase(phase),
+        () => {
+          // Device lost / board killed outside an intentional disconnect.
+          setConnected(false);
+          setConnectPhase(null);
+        },
+        (p) => setPaused(p),
+      ),
+    [],
+  );
+
+  const connect = useCallback(async () => {
+    setConnectPhase('connecting');
+    setConnectError(null);
+    try {
+      await connection.connect();
+      setConnected(true);
+    } catch (e) {
+      setConnectError((e as Error).message);
+    } finally {
+      setConnectPhase(null);
+    }
+  }, [connection]);
+
+  const disconnect = useCallback(async () => {
+    await connection.disconnect();
+    setConnected(false);
+  }, [connection]);
+
+  const emergencyStop = useCallback(async () => {
+    setEmergencyStopped(true);
+    try {
+      await connection.emergencyStop();
+    } finally {
+      // M112 kills the firmware; the port is dead until the board is
+      // reconnected. Tear down so the UI shows disconnected immediately.
+      await connection.disconnect().catch(() => {});
+      setConnected(false);
+      setConnectPhase(null);
+    }
+  }, [connection]);
+
+  const value = useMemo<ConnectionCtx>(
+    () => ({
+      connection,
+      connected,
+      connecting: connectPhase !== null,
+      connectPhase,
+      connect,
+      disconnect,
+      connectError,
+      dismissConnectError: () => setConnectError(null),
+      paused,
+      pause: () => connection.pause(),
+      resume: () => connection.resume(),
+      emergencyStop,
+      emergencyStopped,
+      acknowledgeEmergencyStop: () => setEmergencyStopped(false),
+      log,
+      showLog,
+      setShowLog,
+    }),
+    [
+      connection,
+      connected,
+      connectPhase,
+      connect,
+      disconnect,
+      connectError,
+      paused,
+      emergencyStop,
+      emergencyStopped,
+      log,
+      showLog,
+      setShowLog,
+    ],
+  );
+
+  return <ConnectionContext.Provider value={value}>{children}</ConnectionContext.Provider>;
+};
+
+export const useConnection = () => {
+  const ctx = useContext(ConnectionContext);
+  if (!ctx) throw new Error('useConnection must be used within ConnectionProvider');
+  return ctx;
+};

--- a/paint-app/src/db.ts
+++ b/paint-app/src/db.ts
@@ -1,0 +1,28 @@
+import Dexie, { type Table } from 'dexie';
+import type { AppState, Plotter } from './types';
+
+export type Project = {
+  id: string;
+  name: string;
+  state: AppState;
+  createdAt: number;
+  updatedAt: number;
+};
+
+class PaintDB extends Dexie {
+  projects!: Table<Project, string>;
+  plotters!: Table<Plotter, string>;
+
+  constructor() {
+    super('paint-app');
+    this.version(1).stores({
+      projects: 'id, name, updatedAt',
+    });
+    this.version(2).stores({
+      projects: 'id, name, updatedAt',
+      plotters: 'id, name, createdAt',
+    });
+  }
+}
+
+export const db = new PaintDB();

--- a/paint-app/src/gcode.ts
+++ b/paint-app/src/gcode.ts
@@ -1,0 +1,89 @@
+import { clipPolyline, type Rect } from './clip';
+import type { Layer, Page, Plotter, Point } from './types';
+
+const fmt = (n: number) => n.toFixed(3);
+
+/**
+ * Map a drawing-local point (mm; origin = page top-left, +y down) into
+ * machine coordinates using the plotter's calibrated orientation anchor.
+ * Legacy plotters lack the anchor fields → identity (verbatim local coords).
+ */
+const toMachine = (p: Point, plotter: Plotter): Point => ({
+  x: (plotter.originX ?? 0) + (plotter.dirX ?? 1) * p.x,
+  y: (plotter.originY ?? 0) + (plotter.dirY ?? 1) * p.y,
+});
+
+const pointsToGcode = (points: Point[], plotter: Plotter): string[] => {
+  const lines: string[] = [];
+  const [first, ...rest] = points.map((p) => toMachine(p, plotter));
+  lines.push(`G0 Z${fmt(plotter.penUpZ)} F${plotter.travelFeed}`);
+  lines.push(`G0 X${fmt(first.x)} Y${fmt(first.y)} F${plotter.travelFeed}`);
+  lines.push(`G1 Z${fmt(plotter.penDownZ)} F${plotter.travelFeed}`);
+  for (const p of rest) {
+    lines.push(`G1 X${fmt(p.x)} Y${fmt(p.y)} F${plotter.drawFeed}`);
+  }
+  lines.push(`G0 Z${fmt(plotter.penUpZ)} F${plotter.travelFeed}`);
+  return lines;
+};
+
+export type LayerProgram = {
+  layerId: string;
+  layerName: string;
+  color: string;
+  lines: string[];
+};
+
+/**
+ * Build G-code for a single freshly-drawn stroke, clipped to the page rect
+ * and translated into machine coordinates. Used by interactive mode where we
+ * stream individual strokes as the user finishes them.
+ */
+export const buildStrokeLines = (points: Point[], page: Page, plotter: Plotter): string[] => {
+  const rect: Rect = { x: page.x, y: page.y, width: page.width, height: page.height };
+  const subs = clipPolyline(points, rect);
+  const lines: string[] = [];
+  for (const sub of subs) {
+    const local = sub.map((p) => ({ x: p.x - page.x, y: p.y - page.y }));
+    lines.push(...pointsToGcode(local, plotter));
+  }
+  return lines;
+};
+
+export const buildLayerPrograms = (
+  layers: Layer[],
+  page: Page,
+  plotter: Plotter,
+): LayerProgram[] => {
+  const rect: Rect = { x: page.x, y: page.y, width: page.width, height: page.height };
+  return layers
+    .filter((l) => l.visible)
+    .map((layer) => {
+      const lines: string[] = [`; layer ${layer.name} (${layer.color}, ${layer.thickness}mm)`];
+      let drew = false;
+      for (const stroke of layer.strokes) {
+        const subs = clipPolyline(stroke.points, rect);
+        for (const sub of subs) {
+          const local = sub.map((p) => ({ x: p.x - page.x, y: p.y - page.y }));
+          lines.push(...pointsToGcode(local, plotter));
+          drew = true;
+        }
+      }
+      return drew ? { layerId: layer.id, layerName: layer.name, color: layer.color, lines } : null;
+    })
+    .filter((p): p is LayerProgram => p !== null);
+};
+
+export const PROLOGUE = (plotter: Plotter): string[] => [
+  `; plotter: ${plotter.name}`,
+  'G21 ; mm',
+  'G90 ; absolute',
+  // No G28 here: the device is homed once on connect (serial.ts) and
+  // position persists, so re-homing per print would just waste ~15s.
+  `G0 Z${fmt(plotter.penUpZ)} F${plotter.travelFeed}`,
+];
+
+export const EPILOGUE = (plotter: Plotter): string[] => [
+  `G0 Z${fmt(plotter.penUpZ)} F${plotter.travelFeed}`,
+  'G0 X0 Y0',
+  'M84 ; disable steppers',
+];

--- a/paint-app/src/index.css
+++ b/paint-app/src/index.css
@@ -1,0 +1,23 @@
+:root {
+  font-family: -apple-system, system-ui, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px;
+  color: #1a1a1a;
+  background: #fafafa;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+button {
+  font-family: inherit;
+  font-size: inherit;
+}

--- a/paint-app/src/interactive.tsx
+++ b/paint-app/src/interactive.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useRef } from 'react';
+import { useConnection } from './connection';
+import { buildStrokeLines, PROLOGUE } from './gcode';
+import { usePlotters } from './plotters';
+import { INTERACTIVE_PROJECT_ID, useProject } from './project';
+import { useStore } from './store';
+
+/**
+ * In interactive mode, every freshly-drawn stroke is streamed to the plotter
+ * as soon as the user releases the pointer. Strokes that already existed when
+ * the session started (or that were drawn while disconnected) are NOT
+ * replayed — only new strokes go down the wire.
+ *
+ * The first stroke after a fresh connection sends the prologue (G21/G90/G28).
+ * Strokes are sent through a serialized promise queue so concurrent draws
+ * don't interleave G-code on the bus.
+ */
+export const useInteractiveSync = () => {
+  const { state } = useStore();
+  const { project } = useProject();
+  const { connection, connected } = useConnection();
+  const { getPlotter } = usePlotters();
+
+  const isInteractive = project?.id === INTERACTIVE_PROJECT_ID;
+  const sentRef = useRef<Set<string>>(new Set());
+  const queueRef = useRef<Promise<void>>(Promise.resolve());
+  const sessionKeyRef = useRef<string | null>(null);
+
+  // (Re-)prime the "already sent" set whenever we enter the mode or the
+  // connection comes back. This is what stops the existing project history
+  // from being plotted on load.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only re-prime on session-boundary changes
+  useEffect(() => {
+    if (!isInteractive || !connected) {
+      sentRef.current = new Set();
+      sessionKeyRef.current = null;
+      return;
+    }
+    const ids = new Set<string>();
+    for (const layer of state.layers) {
+      for (const stroke of layer.strokes) ids.add(stroke.id);
+    }
+    sentRef.current = ids;
+    sessionKeyRef.current = null;
+  }, [isInteractive, connected, project?.id]);
+
+  // Stream new strokes whenever the store changes.
+  useEffect(() => {
+    if (!isInteractive || !connected || !project) return;
+    const plotter = getPlotter(state.plotterId);
+    if (!plotter) return;
+    const activePage = state.pages.find((p) => p.id === state.activePageId);
+    if (!activePage) return;
+
+    const expectedSession = `${project.id}:${plotter.id}`;
+    const newPrograms: string[][] = [];
+
+    for (const layer of state.layers) {
+      if (!layer.visible) continue;
+      for (const stroke of layer.strokes) {
+        if (sentRef.current.has(stroke.id)) continue;
+        sentRef.current.add(stroke.id);
+        const lines = buildStrokeLines(stroke.points, activePage, plotter);
+        if (lines.length > 0) newPrograms.push(lines);
+      }
+    }
+
+    if (newPrograms.length === 0) return;
+
+    queueRef.current = queueRef.current.then(async () => {
+      try {
+        if (sessionKeyRef.current !== expectedSession) {
+          await connection.sendMany(PROLOGUE(plotter));
+          sessionKeyRef.current = expectedSession;
+        }
+        for (const lines of newPrograms) {
+          await connection.sendMany(lines);
+        }
+      } catch (e) {
+        console.error('interactive stream failed', e);
+      }
+    });
+  }, [state, isInteractive, connected, project, connection, getPlotter]);
+};

--- a/paint-app/src/main.tsx
+++ b/paint-app/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+import './index.css';
+
+const root = document.getElementById('root');
+if (!root) throw new Error('#root not found');
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/paint-app/src/plotters.tsx
+++ b/paint-app/src/plotters.tsx
@@ -1,0 +1,119 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { db } from './db';
+import type { Plotter } from './types';
+
+const uid = () => Math.random().toString(36).slice(2, 10);
+
+export type PlotterDraft = Omit<Plotter, 'id' | 'createdAt'>;
+
+type PlottersCtx = {
+  plotters: Plotter[];
+  ready: boolean;
+  createPlotter: (draft: PlotterDraft) => Promise<Plotter>;
+  /**
+   * Overwrite an existing plotter's parameters in place (id and createdAt
+   * are preserved). Every project referencing this plotter by id will use
+   * the new values next time it builds G-code.
+   */
+  updatePlotter: (id: string, draft: PlotterDraft) => Promise<Plotter>;
+  /**
+   * Insert a plotter snapshot (e.g. from imported JSON), preserving its
+   * id if there is no collision. Returns the canonical plotter that should
+   * be referenced going forward.
+   */
+  ingestPlotter: (snapshot: Plotter) => Promise<Plotter>;
+  deletePlotter: (id: string) => Promise<void>;
+  getPlotter: (id: string) => Plotter | undefined;
+};
+
+const PlottersContext = createContext<PlottersCtx | null>(null);
+
+export const PlottersProvider = ({ children }: { children: ReactNode }) => {
+  const [plotters, setPlotters] = useState<Plotter[]>([]);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const all = await db.plotters.orderBy('createdAt').toArray();
+      if (!cancelled) {
+        setPlotters(all);
+        setReady(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const createPlotter = useCallback(async (draft: PlotterDraft) => {
+    const plotter: Plotter = { id: uid(), ...draft, createdAt: Date.now() };
+    await db.plotters.put(plotter);
+    setPlotters((prev) => [...prev, plotter].sort((a, b) => a.createdAt - b.createdAt));
+    return plotter;
+  }, []);
+
+  const ingestPlotter = useCallback(async (snapshot: Plotter) => {
+    const existing = await db.plotters.get(snapshot.id);
+    if (existing) return existing;
+    await db.plotters.put(snapshot);
+    setPlotters((prev) => [...prev, snapshot].sort((a, b) => a.createdAt - b.createdAt));
+    return snapshot;
+  }, []);
+
+  const updatePlotter = useCallback(async (id: string, draft: PlotterDraft) => {
+    const existing = await db.plotters.get(id);
+    if (!existing) throw new Error('Plotter not found');
+    const updated: Plotter = { ...existing, ...draft, id, createdAt: existing.createdAt };
+    await db.plotters.put(updated);
+    setPlotters((prev) =>
+      prev.map((p) => (p.id === id ? updated : p)).sort((a, b) => a.createdAt - b.createdAt),
+    );
+    return updated;
+  }, []);
+
+  const deletePlotter = useCallback(async (id: string) => {
+    await db.plotters.delete(id);
+    setPlotters((prev) => prev.filter((p) => p.id !== id));
+  }, []);
+
+  const getPlotter = useCallback((id: string) => plotters.find((p) => p.id === id), [plotters]);
+
+  const value = useMemo<PlottersCtx>(
+    () => ({
+      plotters,
+      ready,
+      createPlotter,
+      updatePlotter,
+      ingestPlotter,
+      deletePlotter,
+      getPlotter,
+    }),
+    [plotters, ready, createPlotter, updatePlotter, ingestPlotter, deletePlotter, getPlotter],
+  );
+
+  return <PlottersContext.Provider value={value}>{children}</PlottersContext.Provider>;
+};
+
+export const usePlotters = () => {
+  const ctx = useContext(PlottersContext);
+  if (!ctx) throw new Error('usePlotters must be used within PlottersProvider');
+  return ctx;
+};
+
+/**
+ * Resolve the active project's plotter. Returns null if no plotter has been
+ * selected yet, or if the referenced plotter no longer exists.
+ */
+export const useActivePlotter = (plotterId: string): Plotter | null => {
+  const { getPlotter } = usePlotters();
+  return getPlotter(plotterId) ?? null;
+};

--- a/paint-app/src/project.tsx
+++ b/paint-app/src/project.tsx
@@ -1,0 +1,174 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { db } from './db';
+import { useStore } from './store';
+import type { AppState } from './types';
+
+const AUTOSAVE_LS_KEY = 'paint-app:autosave';
+const AUTOSAVE_DEBOUNCE_MS = 800;
+
+/**
+ * Reserved id for the singleton "Interactive" project. There can only be one
+ * interactive session, so we key it by a fixed id rather than a fresh uid.
+ */
+export const INTERACTIVE_PROJECT_ID = '__interactive__';
+
+export type ProjectMeta = { id: string; name: string };
+
+type ProjectCtx = {
+  project: ProjectMeta | null;
+  setProject: (meta: ProjectMeta, initialState: AppState) => void;
+  closeProject: () => void;
+  renameProject: (name: string) => Promise<void>;
+  deleteProject: () => Promise<void>;
+  autosave: boolean;
+  setAutosave: (v: boolean) => void;
+  isDirty: boolean;
+  isSaving: boolean;
+  saveNow: () => Promise<void>;
+};
+
+const ProjectContext = createContext<ProjectCtx | null>(null);
+
+export const ProjectProvider = ({ children }: { children: ReactNode }) => {
+  const { state, loadState } = useStore();
+  const [project, setProjectState] = useState<ProjectMeta | null>(null);
+  const [autosave, setAutosaveState] = useState<boolean>(() => {
+    const raw = localStorage.getItem(AUTOSAVE_LS_KEY);
+    return raw === null ? true : raw === '1';
+  });
+  const [isDirty, setIsDirty] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // After loadState, the next state-change effect would mark the project dirty
+  // even though nothing user-visible changed. Suppress that one tick.
+  const skipNextDirty = useRef(false);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: we depend on state changing, not its contents
+  useEffect(() => {
+    if (!project) return;
+    // Interactive sessions are ephemeral; never mark them dirty so we don't
+    // autosave them or trip the beforeunload guard.
+    if (project.id === INTERACTIVE_PROJECT_ID) return;
+    if (skipNextDirty.current) {
+      skipNextDirty.current = false;
+      return;
+    }
+    setIsDirty(true);
+  }, [state, project]);
+
+  const setAutosave = useCallback((v: boolean) => {
+    setAutosaveState(v);
+    localStorage.setItem(AUTOSAVE_LS_KEY, v ? '1' : '0');
+  }, []);
+
+  const setProject = useCallback(
+    (meta: ProjectMeta, initialState: AppState) => {
+      skipNextDirty.current = true;
+      loadState(initialState);
+      setProjectState(meta);
+      setIsDirty(false);
+    },
+    [loadState],
+  );
+
+  const closeProject = useCallback(() => {
+    setProjectState(null);
+    setIsDirty(false);
+  }, []);
+
+  const saveNow = useCallback(async () => {
+    if (!project || project.id === INTERACTIVE_PROJECT_ID) return;
+    setIsSaving(true);
+    try {
+      await db.projects.update(project.id, {
+        state,
+        updatedAt: Date.now(),
+      });
+      setIsDirty(false);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [project, state]);
+
+  const renameProject = useCallback(
+    async (name: string) => {
+      if (!project || project.id === INTERACTIVE_PROJECT_ID) return;
+      await db.projects.update(project.id, { name, updatedAt: Date.now() });
+      setProjectState({ ...project, name });
+    },
+    [project],
+  );
+
+  const deleteProject = useCallback(async () => {
+    if (!project || project.id === INTERACTIVE_PROJECT_ID) return;
+    await db.projects.delete(project.id);
+    setProjectState(null);
+    setIsDirty(false);
+  }, [project]);
+
+  // Debounced autosave.
+  useEffect(() => {
+    if (!autosave || !isDirty || !project) return;
+    if (project.id === INTERACTIVE_PROJECT_ID) return;
+    const t = setTimeout(() => {
+      saveNow();
+    }, AUTOSAVE_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [autosave, isDirty, project, saveNow]);
+
+  // beforeunload guard while there are unsaved changes.
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (isDirty || isSaving) {
+        e.preventDefault();
+        e.returnValue = '';
+      }
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [isDirty, isSaving]);
+
+  const value = useMemo<ProjectCtx>(
+    () => ({
+      project,
+      setProject,
+      closeProject,
+      renameProject,
+      deleteProject,
+      autosave,
+      setAutosave,
+      isDirty,
+      isSaving,
+      saveNow,
+    }),
+    [
+      project,
+      setProject,
+      closeProject,
+      renameProject,
+      deleteProject,
+      autosave,
+      setAutosave,
+      isDirty,
+      isSaving,
+      saveNow,
+    ],
+  );
+
+  return <ProjectContext.Provider value={value}>{children}</ProjectContext.Provider>;
+};
+
+export const useProject = () => {
+  const ctx = useContext(ProjectContext);
+  if (!ctx) throw new Error('useProject must be used within ProjectProvider');
+  return ctx;
+};

--- a/paint-app/src/script-api.ts
+++ b/paint-app/src/script-api.ts
@@ -1,0 +1,61 @@
+import { buildEllipse, buildLine, buildPolygon, buildRect, buildStar } from './shapes';
+import type { Page, Point } from './types';
+
+/**
+ * Drawing API exposed to user-written scripts. All coordinates are page-local
+ * (origin at the active page's top-left, in mm) — the runtime translates them
+ * into world space before adding strokes to the layer.
+ */
+export type DrawAPI = {
+  rect: (x: number, y: number, w: number, h: number) => void;
+  square: (x: number, y: number, size: number) => void;
+  line: (x1: number, y1: number, x2: number, y2: number) => void;
+  ellipse: (cx: number, cy: number, rx: number, ry: number) => void;
+  circle: (cx: number, cy: number, r: number) => void;
+  polygon: (cx: number, cy: number, r: number, sides: number, rotation?: number) => void;
+  star: (cx: number, cy: number, r: number, points: number) => void;
+  path: (points: Point[]) => void;
+  repeat: (n: number, fn: (i: number) => void) => void;
+};
+
+export const createDrawAPI = (page: Page, emit: (points: Point[]) => void): DrawAPI => {
+  const emitLocal = (points: Point[]) => {
+    if (points.length < 2) return;
+    emit(points.map((p) => ({ x: p.x + page.x, y: p.y + page.y })));
+  };
+
+  return {
+    rect: (x, y, w, h) => emitLocal(buildRect({ x, y }, { x: x + w, y: y + h })),
+    square: (x, y, size) => emitLocal(buildRect({ x, y }, { x: x + size, y: y + size })),
+    line: (x1, y1, x2, y2) => emitLocal(buildLine({ x: x1, y: y1 }, { x: x2, y: y2 })),
+    ellipse: (cx, cy, rx, ry) =>
+      emitLocal(buildEllipse({ x: cx - rx, y: cy - ry }, { x: cx + rx, y: cy + ry })),
+    circle: (cx, cy, r) =>
+      emitLocal(buildEllipse({ x: cx - r, y: cy - r }, { x: cx + r, y: cy + r })),
+    polygon: (cx, cy, r, sides, rotation = 0) =>
+      emitLocal(
+        buildPolygon(
+          { x: cx, y: cy },
+          { x: cx + Math.cos(rotation) * r, y: cy + Math.sin(rotation) * r },
+          sides,
+        ),
+      ),
+    star: (cx, cy, r, points) =>
+      emitLocal(buildStar({ x: cx, y: cy }, { x: cx + r, y: cy }, points)),
+    path: (pts) => emitLocal(pts),
+    repeat: (n, fn) => {
+      for (let i = 0; i < n; i++) fn(i);
+    },
+  };
+};
+
+/**
+ * Execute user-supplied JavaScript with the API surface destructured into
+ * scope, so users can write `rect(0,0,10,10)` rather than `api.rect(...)`.
+ */
+export const runScript = (code: string, api: DrawAPI): void => {
+  const keys = Object.keys(api);
+  const values = Object.values(api);
+  const fn = new Function(...keys, code);
+  fn(...values);
+};

--- a/paint-app/src/serial.ts
+++ b/paint-app/src/serial.ts
@@ -1,0 +1,322 @@
+declare global {
+  interface Navigator {
+    serial: {
+      requestPort: (opts?: { filters?: { usbVendorId: number }[] }) => Promise<SerialPort>;
+      getPorts: () => Promise<SerialPort[]>;
+    };
+  }
+  interface SerialPort {
+    open: (opts: { baudRate: number }) => Promise<void>;
+    close: () => Promise<void>;
+    // null while the port is closed (per the Web Serial spec); the non-null
+    // types are only valid once open() has resolved.
+    readable: ReadableStream<Uint8Array> | null;
+    writable: WritableStream<Uint8Array> | null;
+  }
+}
+
+const BAUD = 115200;
+
+export type LogFn = (line: string, kind: 'tx' | 'rx' | 'info' | 'err') => void;
+export type ConnectPhase = 'connecting' | 'homing';
+export type PhaseFn = (phase: ConnectPhase | null) => void;
+
+export class PlotterConnection {
+  private port: SerialPort | null = null;
+  private writer: WritableStreamDefaultWriter<Uint8Array> | null = null;
+  private reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  private buffer = '';
+  /** Lines received but not yet consumed by a reader. */
+  private lineQueue: string[] = [];
+  /** Resolver for a reader currently awaiting the next line, if any. */
+  private lineWaiter: ((line: string) => void) | null = null;
+  private readLoopPromise: Promise<void> | null = null;
+  /** True only while an intentional disconnect() is in progress, so the
+   * read loop ending doesn't get misreported as an unexpected device loss. */
+  private intentionalClose = false;
+  /** When true, the next send() blocks before writing until resume(). The
+   * in-flight line still finishes; Marlin then drains its small planner
+   * buffer and holds position. Applies to every G-code source (print,
+   * interactive) since they all funnel through send(). */
+  private paused = false;
+  private resumeWaiters: (() => void)[] = [];
+
+  constructor(
+    private log: LogFn,
+    private onPhase: PhaseFn = () => {},
+    /** Fired once when the port drops unexpectedly (device lost, board
+     * reset/killed by M112). Not called for an intentional disconnect(). */
+    private onLost: () => void = () => {},
+    private onPauseChange: (paused: boolean) => void = () => {},
+  ) {}
+
+  get isPaused() {
+    return this.paused;
+  }
+
+  pause() {
+    if (this.paused) return;
+    this.paused = true;
+    this.log('paused', 'info');
+    this.onPauseChange(true);
+  }
+
+  resume() {
+    if (!this.paused) return;
+    this.paused = false;
+    const waiters = this.resumeWaiters;
+    this.resumeWaiters = [];
+    for (const w of waiters) w();
+    this.log('resumed', 'info');
+    this.onPauseChange(false);
+  }
+
+  /** Resolves immediately unless paused, in which case it waits for resume()
+   * (or a disconnect, which forcibly clears the pause). */
+  private gate(): Promise<void> {
+    if (!this.paused) return Promise.resolve();
+    return new Promise<void>((r) => this.resumeWaiters.push(r));
+  }
+
+  get connected() {
+    return this.port !== null;
+  }
+
+  async connect() {
+    if (!('serial' in navigator)) {
+      throw new Error('Web Serial not supported. Use Chrome or Edge.');
+    }
+    if (this.port) {
+      throw new Error('Already connected. Disconnect before connecting again.');
+    }
+    const port = await navigator.serial.requestPort();
+    this.onPhase('connecting');
+    // The browser keeps a port open across our own teardown bugs, other tabs,
+    // or a prior connect() that threw after open() — re-opening such a port
+    // fails with "The port is already open." A non-null readable/writable is
+    // the spec's signal that it's still open, so close it for a clean start.
+    if (port.readable || port.writable) {
+      this.log('port already open — closing before reopening', 'info');
+      await port.close().catch(() => {});
+      // The OS doesn't release the device synchronously with close(); opening
+      // again immediately fails with the generic "Failed to open serial port."
+      // Give the previous handle time to drop before reopening.
+      await new Promise((r) => setTimeout(r, 300));
+    }
+    try {
+      await port.open({ baudRate: BAUD });
+    } catch (e) {
+      // A transient "Failed to open serial port" usually means the OS hasn't
+      // freed the device yet (just unplugged/replugged, prior session, another
+      // tab). One delayed retry clears the common case; a second failure is
+      // surfaced with actionable guidance.
+      this.log(`open failed (${(e as Error).message}) — retrying once`, 'info');
+      await new Promise((r) => setTimeout(r, 800));
+      try {
+        await port.open({ baudRate: BAUD });
+      } catch {
+        throw new Error(
+          'Could not open the serial port. Close any other tab or program using the plotter (including Arduino IDE / serial monitors), then unplug and replug the USB cable and try again.',
+        );
+      }
+    }
+    if (!port.writable || !port.readable) {
+      await port.close().catch(() => {});
+      throw new Error('Serial port opened without readable/writable streams.');
+    }
+    this.port = port;
+    this.writer = port.writable.getWriter();
+    this.readLoopPromise = this.readLoop();
+    this.log(`opened @ ${BAUD}`, 'info');
+    // Marlin resets on open; wait for boot.
+    this.log('boot wait 2000ms…', 'info');
+    await new Promise((r) => setTimeout(r, 2000));
+    this.log('boot wait done; sending M115', 'info');
+    // M115 is the liveness probe: a healthy Marlin always replies with a
+    // FIRMWARE_NAME banner. A board that's been M112'd / killed answers
+    // nothing, so a short timeout here lets us fail fast instead of
+    // marching on (M115 timeout → G28 timeout) and falsely reporting a
+    // live connection to a dead board.
+    const info = await this.send('M115', 6_000);
+    const alive = info.some((l) => /FIRMWARE_NAME|marlin/i.test(l));
+    if (!alive) {
+      this.log('no firmware response — board not responding', 'err');
+      await this.disconnect().catch(() => {});
+      throw new Error(
+        'Plotter is not responding. If it was emergency-stopped, power-cycle the printer (off, wait, on), then reconnect.',
+      );
+    }
+    this.log('M115 done; sending G28 (home)', 'info');
+    this.onPhase('homing');
+    await this.send('G28');
+    this.log('G28 done; connected', 'info');
+    this.onPhase(null);
+  }
+
+  async disconnect() {
+    this.intentionalClose = true;
+    // Release anything blocked on a pause so the print/interactive loops
+    // can unwind instead of hanging on a closed port.
+    this.paused = false;
+    const waiters = this.resumeWaiters;
+    this.resumeWaiters = [];
+    for (const w of waiters) w();
+    this.onPauseChange(false);
+    try {
+      this.reader?.cancel();
+      this.writer?.releaseLock();
+      await this.readLoopPromise;
+      await this.port?.close();
+    } finally {
+      this.port = null;
+      this.writer = null;
+      this.reader = null;
+      this.readLoopPromise = null;
+      this.intentionalClose = false;
+      this.log('closed', 'info');
+    }
+  }
+
+  private async readLoop() {
+    if (!this.port?.readable) return;
+    const decoder = new TextDecoder();
+    this.reader = this.port.readable.getReader();
+    try {
+      while (true) {
+        const { value, done } = await this.reader.read();
+        if (done) break;
+        this.buffer += decoder.decode(value, { stream: true });
+        let nl: number;
+        // biome-ignore lint/suspicious/noAssignInExpressions: idiomatic line splitting
+        while ((nl = this.buffer.indexOf('\n')) >= 0) {
+          const line = this.buffer.slice(0, nl).replace(/\r$/, '');
+          this.buffer = this.buffer.slice(nl + 1);
+          if (!line) continue;
+          this.log(line, 'rx');
+          this.pushLine(line);
+        }
+      }
+    } catch (e) {
+      this.log(`read error: ${(e as Error).message}`, 'err');
+    } finally {
+      try {
+        this.reader?.releaseLock();
+      } catch {}
+      // Loop ended without an intentional disconnect() → the device was
+      // lost (unplugged, reset, or killed by M112). Drop state and notify
+      // so the UI stops showing a live connection.
+      if (!this.intentionalClose && this.port) {
+        this.port = null;
+        this.writer = null;
+        this.reader = null;
+        this.readLoopPromise = null;
+        this.log('connection lost', 'err');
+        this.onLost();
+      }
+    }
+  }
+
+  /** Deliver a line to a waiting reader, or buffer it until one asks. */
+  private pushLine(line: string) {
+    if (this.lineWaiter) {
+      const w = this.lineWaiter;
+      this.lineWaiter = null;
+      w(line);
+    } else {
+      this.lineQueue.push(line);
+    }
+  }
+
+  private nextLine(timeoutMs: number) {
+    const queued = this.lineQueue.shift();
+    if (queued !== undefined) return Promise.resolve<string | null>(queued);
+    return new Promise<string | null>((resolve) => {
+      let done = false;
+      const t = setTimeout(() => {
+        if (!done) {
+          done = true;
+          this.lineWaiter = null;
+          resolve(null);
+        }
+      }, timeoutMs);
+      this.lineWaiter = (line) => {
+        if (!done) {
+          done = true;
+          clearTimeout(t);
+          resolve(line);
+        }
+      };
+    });
+  }
+
+  /**
+   * Collect reply lines until `ok`. Uses an *inactivity* timeout, not a hard
+   * deadline: slow commands like `G28` can take far longer than any fixed
+   * budget, and Marlin emits `echo:busy: processing` every ~2s precisely so
+   * the host knows it is still alive. We treat those as keepalives that keep
+   * us waiting; we only give up after `idleTimeoutMs` of true silence.
+   */
+  private async readUntilOk(idleTimeoutMs = 20_000): Promise<string[]> {
+    const collected: string[] = [];
+    while (true) {
+      const line = await this.nextLine(idleTimeoutMs);
+      if (line === null) return collected;
+      const lower = line.toLowerCase();
+      if (lower.startsWith('ok')) return collected;
+      if (lower.startsWith('echo:busy') || lower.startsWith('busy')) continue;
+      collected.push(line);
+    }
+  }
+
+  /** Send a single G-code line; returns any non-`ok` reply lines it produced. */
+  async send(gcode: string, idleTimeoutMs?: number): Promise<string[]> {
+    // Strip comments; Marlin sends no `ok` for a comment-only line, so
+    // sending one would stall readUntilOk for the full idle timeout.
+    const line = gcode.replace(/;.*$/, '').trim();
+    if (!line) return [];
+    // Block here while paused so the *next* line isn't sent; the previous
+    // line already got its `ok`, so the machine just holds position.
+    await this.gate();
+    if (!this.writer) return [];
+    // Drop any lines left over from a previous command (e.g. trailing
+    // async chatter after its `ok`) so they aren't mistaken for this reply.
+    this.lineQueue.length = 0;
+    this.log(line, 'tx');
+    await this.writer.write(new TextEncoder().encode(`${line}\n`));
+    return this.readUntilOk(idleTimeoutMs);
+  }
+
+  async sendMany(lines: string[]) {
+    for (const l of lines) {
+      await this.send(l);
+    }
+  }
+
+  /**
+   * Emergency stop. Writes M112 straight to the port, bypassing the
+   * command/`ok` queue so it lands even mid-stream (Marlin's
+   * EMERGENCY_PARSER acts on it immediately, full planner buffer or not).
+   * The board enters a killed state afterwards and must be reconnected.
+   */
+  async emergencyStop() {
+    if (!this.writer) return;
+    this.log('M112 (emergency stop)', 'err');
+    await this.writer.write(new TextEncoder().encode('M112\n'));
+  }
+
+  /** Query M114 and parse the X/Y/Z position from the reply. Null if no reply. */
+  async getPosition(): Promise<{ x: number; y: number; z: number } | null> {
+    const lines = await this.send('M114');
+    for (const line of lines) {
+      const m = line.match(/X:(-?\d+\.?\d*)\s+Y:(-?\d+\.?\d*)\s+Z:(-?\d+\.?\d*)/);
+      if (m) {
+        return {
+          x: Number.parseFloat(m[1]),
+          y: Number.parseFloat(m[2]),
+          z: Number.parseFloat(m[3]),
+        };
+      }
+    }
+    return null;
+  }
+}

--- a/paint-app/src/shapes.ts
+++ b/paint-app/src/shapes.ts
@@ -1,0 +1,66 @@
+import type { Point } from './types';
+
+const ELLIPSE_SAMPLES = 64;
+
+export const buildLine = (a: Point, b: Point): Point[] => [a, b];
+
+export const buildRect = (a: Point, b: Point): Point[] => {
+  const x1 = Math.min(a.x, b.x);
+  const y1 = Math.min(a.y, b.y);
+  const x2 = Math.max(a.x, b.x);
+  const y2 = Math.max(a.y, b.y);
+  return [
+    { x: x1, y: y1 },
+    { x: x2, y: y1 },
+    { x: x2, y: y2 },
+    { x: x1, y: y2 },
+    { x: x1, y: y1 },
+  ];
+};
+
+/** Drag defines the bounding box; we sample the inscribed ellipse as a polyline. */
+export const buildEllipse = (a: Point, b: Point, samples = ELLIPSE_SAMPLES): Point[] => {
+  const cx = (a.x + b.x) / 2;
+  const cy = (a.y + b.y) / 2;
+  const rx = Math.abs(b.x - a.x) / 2;
+  const ry = Math.abs(b.y - a.y) / 2;
+  const points: Point[] = [];
+  for (let i = 0; i <= samples; i++) {
+    const t = (i / samples) * 2 * Math.PI;
+    points.push({ x: cx + rx * Math.cos(t), y: cy + ry * Math.sin(t) });
+  }
+  return points;
+};
+
+/** Drag goes from the polygon center to one of its vertices. */
+export const buildPolygon = (center: Point, edge: Point, sides: number): Point[] => {
+  const dx = edge.x - center.x;
+  const dy = edge.y - center.y;
+  const r = Math.sqrt(dx * dx + dy * dy);
+  const baseAngle = Math.atan2(dy, dx);
+  const n = Math.max(3, Math.floor(sides));
+  const points: Point[] = [];
+  for (let i = 0; i <= n; i++) {
+    const t = baseAngle + (i / n) * 2 * Math.PI;
+    points.push({ x: center.x + r * Math.cos(t), y: center.y + r * Math.sin(t) });
+  }
+  return points;
+};
+
+/** Drag goes from the star center to one of its outer points. Inner radius = outer/2. */
+export const buildStar = (center: Point, edge: Point, pointCount: number): Point[] => {
+  const dx = edge.x - center.x;
+  const dy = edge.y - center.y;
+  const rOuter = Math.sqrt(dx * dx + dy * dy);
+  const rInner = rOuter / 2;
+  const baseAngle = Math.atan2(dy, dx);
+  const n = Math.max(3, Math.floor(pointCount));
+  const total = n * 2;
+  const points: Point[] = [];
+  for (let i = 0; i <= total; i++) {
+    const r = i % 2 === 0 ? rOuter : rInner;
+    const t = baseAngle + (i / total) * 2 * Math.PI;
+    points.push({ x: center.x + r * Math.cos(t), y: center.y + r * Math.sin(t) });
+  }
+  return points;
+};

--- a/paint-app/src/store.tsx
+++ b/paint-app/src/store.tsx
@@ -1,0 +1,251 @@
+import { createContext, type ReactNode, useCallback, useContext, useMemo, useReducer } from 'react';
+import type { AppState, Layer, Page, Plotter, Point, Stroke } from './types';
+
+const uid = () => Math.random().toString(36).slice(2, 10);
+
+const HISTORY_LIMIT = 100;
+
+/**
+ * Create a fresh AppState for a new project. The plotter governs both the
+ * referenced id and the initial page dimensions (which match the bed so the
+ * default canvas fills the printable area).
+ */
+export const createInitialState = (plotter: Plotter): AppState => {
+  const pageId = uid();
+  const layerId = uid();
+  return {
+    pages: [{ id: pageId, x: 0, y: 0, width: plotter.bedWidth, height: plotter.bedHeight }],
+    layers: [
+      {
+        id: layerId,
+        name: 'Layer 1',
+        color: '#1a1a1a',
+        thickness: 0.5,
+        visible: true,
+        strokes: [],
+      },
+    ],
+    activePageId: pageId,
+    activeLayerId: layerId,
+    plotterId: plotter.id,
+  };
+};
+
+const PLACEHOLDER_STATE: AppState = {
+  pages: [{ id: 'placeholder', x: 0, y: 0, width: 210, height: 297 }],
+  layers: [
+    {
+      id: 'placeholder-layer',
+      name: 'Layer 1',
+      color: '#1a1a1a',
+      thickness: 0.5,
+      visible: true,
+      strokes: [],
+    },
+  ],
+  activePageId: 'placeholder',
+  activeLayerId: 'placeholder-layer',
+  plotterId: '',
+};
+
+export type AddDirection = 'top' | 'right' | 'bottom' | 'left';
+
+type Action =
+  | { type: 'add-page'; direction: AddDirection }
+  | { type: 'remove-page'; pageId: string }
+  | { type: 'set-active-page'; pageId: string }
+  | { type: 'update-page'; pageId: string; patch: Partial<Page> }
+  | { type: 'add-layer' }
+  | { type: 'remove-layer'; layerId: string }
+  | { type: 'set-active-layer'; layerId: string }
+  | { type: 'update-layer'; layerId: string; patch: Partial<Layer> }
+  | { type: 'reorder-layers'; ids: string[] }
+  | { type: 'add-stroke'; layerId: string; stroke: Stroke }
+  | { type: 'clear-strokes' }
+  | { type: 'load-state'; state: AppState }
+  | { type: 'undo' };
+
+/**
+ * Action types whose effect is reversible — these get pushed onto the
+ * history stack before being applied. Pure-selection actions (set-active-*)
+ * and `load-state` are excluded.
+ */
+const UNDOABLE: Set<Action['type']> = new Set([
+  'add-page',
+  'remove-page',
+  'update-page',
+  'add-layer',
+  'remove-layer',
+  'update-layer',
+  'reorder-layers',
+  'add-stroke',
+  'clear-strokes',
+]);
+
+type ReducerState = { present: AppState; past: AppState[] };
+
+const presentReducer = (state: AppState, action: Action): AppState => {
+  switch (action.type) {
+    case 'load-state':
+    case 'undo':
+      return state; // handled at the wrapper level
+    case 'add-page': {
+      const src =
+        state.pages.find((p) => p.id === state.activePageId) ?? state.pages[state.pages.length - 1];
+      const page: Page = (() => {
+        const base = { id: uid(), width: src.width, height: src.height };
+        switch (action.direction) {
+          case 'right':
+            return { ...base, x: src.x + src.width, y: src.y };
+          case 'left':
+            return { ...base, x: src.x - src.width, y: src.y };
+          case 'bottom':
+            return { ...base, x: src.x, y: src.y + src.height };
+          case 'top':
+            return { ...base, x: src.x, y: src.y - src.height };
+        }
+      })();
+      return { ...state, pages: [...state.pages, page], activePageId: page.id };
+    }
+    case 'remove-page': {
+      if (state.pages.length === 1) return state;
+      const pages = state.pages.filter((p) => p.id !== action.pageId);
+      const activePageId = state.activePageId === action.pageId ? pages[0].id : state.activePageId;
+      return { ...state, pages, activePageId };
+    }
+    case 'set-active-page':
+      return { ...state, activePageId: action.pageId };
+    case 'update-page':
+      return {
+        ...state,
+        pages: state.pages.map((p) => (p.id === action.pageId ? { ...p, ...action.patch } : p)),
+      };
+    case 'add-layer': {
+      const layer: Layer = {
+        id: uid(),
+        name: `Layer ${state.layers.length + 1}`,
+        color: '#1a1a1a',
+        thickness: 0.5,
+        visible: true,
+        strokes: [],
+      };
+      return { ...state, layers: [...state.layers, layer], activeLayerId: layer.id };
+    }
+    case 'remove-layer': {
+      if (state.layers.length === 1) return state;
+      const layers = state.layers.filter((l) => l.id !== action.layerId);
+      const activeLayerId =
+        state.activeLayerId === action.layerId ? layers[0].id : state.activeLayerId;
+      return { ...state, layers, activeLayerId };
+    }
+    case 'set-active-layer':
+      return { ...state, activeLayerId: action.layerId };
+    case 'update-layer':
+      return {
+        ...state,
+        layers: state.layers.map((l) => (l.id === action.layerId ? { ...l, ...action.patch } : l)),
+      };
+    case 'reorder-layers': {
+      const map = new Map(state.layers.map((l) => [l.id, l]));
+      const layers = action.ids.map((id) => map.get(id)).filter((l): l is Layer => l !== undefined);
+      return layers.length === state.layers.length ? { ...state, layers } : state;
+    }
+    case 'add-stroke':
+      return {
+        ...state,
+        layers: state.layers.map((l) =>
+          l.id === action.layerId ? { ...l, strokes: [...l.strokes, action.stroke] } : l,
+        ),
+      };
+    case 'clear-strokes': {
+      if (state.layers.every((l) => l.strokes.length === 0)) return state;
+      return {
+        ...state,
+        layers: state.layers.map((l) => (l.strokes.length === 0 ? l : { ...l, strokes: [] })),
+      };
+    }
+  }
+};
+
+const reducer = (state: ReducerState, action: Action): ReducerState => {
+  if (action.type === 'load-state') {
+    return { present: action.state, past: [] };
+  }
+  if (action.type === 'undo') {
+    if (state.past.length === 0) return state;
+    const present = state.past[state.past.length - 1];
+    const past = state.past.slice(0, -1);
+    return { present, past };
+  }
+  const next = presentReducer(state.present, action);
+  if (next === state.present) return state;
+  if (UNDOABLE.has(action.type)) {
+    const past = [...state.past, state.present];
+    return { present: next, past: past.slice(-HISTORY_LIMIT) };
+  }
+  return { ...state, present: next };
+};
+
+type Store = {
+  state: AppState;
+  loadState: (state: AppState) => void;
+  addPage: (direction: AddDirection) => void;
+  removePage: (pageId: string) => void;
+  setActivePage: (pageId: string) => void;
+  updatePage: (pageId: string, patch: Partial<Page>) => void;
+  addLayer: () => void;
+  removeLayer: (layerId: string) => void;
+  setActiveLayer: (layerId: string) => void;
+  updateLayer: (layerId: string, patch: Partial<Layer>) => void;
+  reorderLayers: (ids: string[]) => void;
+  addStroke: (layerId: string, points: Point[], color?: string) => void;
+  clearStrokes: () => void;
+  undo: () => void;
+  canUndo: boolean;
+};
+
+const StoreContext = createContext<Store | null>(null);
+
+export const StoreProvider = ({ children }: { children: ReactNode }) => {
+  const [reducerState, dispatch] = useReducer(reducer, {
+    present: PLACEHOLDER_STATE,
+    past: [],
+  });
+
+  const addStroke = useCallback((layerId: string, points: Point[], color?: string) => {
+    dispatch({
+      type: 'add-stroke',
+      layerId,
+      stroke: { id: uid(), points, ...(color ? { color } : {}) },
+    });
+  }, []);
+
+  const value = useMemo<Store>(
+    () => ({
+      state: reducerState.present,
+      canUndo: reducerState.past.length > 0,
+      loadState: (next) => dispatch({ type: 'load-state', state: next }),
+      addPage: (direction) => dispatch({ type: 'add-page', direction }),
+      removePage: (pageId) => dispatch({ type: 'remove-page', pageId }),
+      setActivePage: (pageId) => dispatch({ type: 'set-active-page', pageId }),
+      updatePage: (pageId, patch) => dispatch({ type: 'update-page', pageId, patch }),
+      addLayer: () => dispatch({ type: 'add-layer' }),
+      removeLayer: (layerId) => dispatch({ type: 'remove-layer', layerId }),
+      setActiveLayer: (layerId) => dispatch({ type: 'set-active-layer', layerId }),
+      updateLayer: (layerId, patch) => dispatch({ type: 'update-layer', layerId, patch }),
+      reorderLayers: (ids) => dispatch({ type: 'reorder-layers', ids }),
+      addStroke,
+      clearStrokes: () => dispatch({ type: 'clear-strokes' }),
+      undo: () => dispatch({ type: 'undo' }),
+    }),
+    [reducerState, addStroke],
+  );
+
+  return <StoreContext.Provider value={value}>{children}</StoreContext.Provider>;
+};
+
+export const useStore = () => {
+  const ctx = useContext(StoreContext);
+  if (!ctx) throw new Error('useStore must be used within StoreProvider');
+  return ctx;
+};

--- a/paint-app/src/types.ts
+++ b/paint-app/src/types.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod';
+
+export const PointSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+});
+export type Point = z.infer<typeof PointSchema>;
+
+export const StrokeSchema = z.object({
+  id: z.string(),
+  points: z.array(PointSchema).min(2),
+  // Per-stroke draw color. When absent the stroke inherits its layer's
+  // color (legacy strokes / layer-colored projects). Set from the active
+  // draw color at creation time so changing color only affects new strokes.
+  color: z.string().optional(),
+});
+export type Stroke = z.infer<typeof StrokeSchema>;
+
+export const LayerSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  color: z.string(),
+  thickness: z.number().positive(),
+  visible: z.boolean(),
+  strokes: z.array(StrokeSchema),
+});
+export type Layer = z.infer<typeof LayerSchema>;
+
+export const PageSchema = z.object({
+  id: z.string(),
+  x: z.number(),
+  y: z.number(),
+  width: z.number().positive(),
+  height: z.number().positive(),
+});
+export type Page = z.infer<typeof PageSchema>;
+
+export const PlotterSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  bedWidth: z.number().positive(),
+  bedHeight: z.number().positive(),
+  travelFeed: z.number().positive(),
+  drawFeed: z.number().positive(),
+  penUpZ: z.number(),
+  penDownZ: z.number(),
+  // Orientation anchor captured during calibration. Maps drawing-local mm
+  // (origin = page top-left, +y is down) onto machine coordinates:
+  //   machineX = originX + dirX * localX
+  //   machineY = originY + dirY * localY
+  // dirX/dirY are ±1 and absorb a plotter whose X and/or Y runs backwards.
+  // Absent on legacy plotters → treated as originX/Y 0, dirX/Y +1 (the
+  // pre-calibration behavior of emitting local coords verbatim).
+  originX: z.number().optional(),
+  originY: z.number().optional(),
+  dirX: z.union([z.literal(1), z.literal(-1)]).optional(),
+  dirY: z.union([z.literal(1), z.literal(-1)]).optional(),
+  createdAt: z.number(),
+});
+export type Plotter = z.infer<typeof PlotterSchema>;
+
+export const AppStateSchema = z.object({
+  pages: z.array(PageSchema).min(1),
+  layers: z.array(LayerSchema).min(1),
+  activePageId: z.string(),
+  activeLayerId: z.string(),
+  plotterId: z.string(),
+});
+export type AppState = z.infer<typeof AppStateSchema>;
+
+/**
+ * Pre-plotter v1 state shape — kept around so we can migrate older projects
+ * (which embedded plotter params inline as `settings`) into the new
+ * plotter-by-id model.
+ */
+export const LegacyAppStateSchema = z.object({
+  pages: z.array(PageSchema).min(1),
+  layers: z.array(LayerSchema).min(1),
+  activePageId: z.string(),
+  activeLayerId: z.string(),
+  settings: z.object({
+    bedWidth: z.number().positive(),
+    bedHeight: z.number().positive(),
+    travelFeed: z.number().positive(),
+    drawFeed: z.number().positive(),
+    penUpZ: z.number(),
+    penDownZ: z.number(),
+  }),
+});
+export type LegacyAppState = z.infer<typeof LegacyAppStateSchema>;

--- a/paint-app/src/ui.tsx
+++ b/paint-app/src/ui.tsx
@@ -1,0 +1,109 @@
+import {
+  createContext,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import type { Point } from './types';
+
+export type Tool = 'pen' | 'line' | 'rect' | 'ellipse' | 'polygon' | 'star';
+
+const GRID_SIZE_LS_KEY = 'paint-app:gridSize';
+export const GRID_SIZE_MIN = 1;
+export const GRID_SIZE_MAX = 100;
+const GRID_SIZE_DEFAULT = 10;
+
+type UICtx = {
+  tool: Tool;
+  setTool: (t: Tool) => void;
+  polygonSides: number;
+  setPolygonSides: (n: number) => void;
+  starPoints: number;
+  setStarPoints: (n: number) => void;
+  zoom: number;
+  setZoom: Dispatch<SetStateAction<number>>;
+  /** Whether a measurement grid is overlaid on each page. Display-only —
+   * never affects exported geometry. */
+  showGrid: boolean;
+  setShowGrid: (v: boolean) => void;
+  /** Grid spacing in mm. Persisted to localStorage; clamped to
+   * [GRID_SIZE_MIN, GRID_SIZE_MAX]. */
+  gridSize: number;
+  setGridSize: (v: number) => void;
+  /** Color applied to newly drawn strokes. Changing it never recolors
+   * existing strokes — each stroke captures this value when committed. */
+  drawColor: string;
+  setDrawColor: (c: string) => void;
+  /** World-space polylines rendered as a ghost overlay while the script
+   * dialog is editing — strokes only commit when the user clicks OK. */
+  scriptPreview: Point[][] | null;
+  setScriptPreview: (preview: Point[][] | null) => void;
+};
+
+const UIContext = createContext<UICtx | null>(null);
+
+export const UIProvider = ({ children }: { children: ReactNode }) => {
+  const [tool, setTool] = useState<Tool>('pen');
+  const [polygonSides, setPolygonSides] = useState(6);
+  const [starPoints, setStarPoints] = useState(5);
+  const [zoom, setZoom] = useState(1);
+  const [showGrid, setShowGrid] = useState(false);
+  const [gridSize, setGridSizeState] = useState<number>(() => {
+    const raw = Number(localStorage.getItem(GRID_SIZE_LS_KEY));
+    return Number.isFinite(raw) && raw >= GRID_SIZE_MIN && raw <= GRID_SIZE_MAX
+      ? raw
+      : GRID_SIZE_DEFAULT;
+  });
+  const [drawColor, setDrawColor] = useState('#1a1a1a');
+
+  const setGridSize = useCallback((v: number) => {
+    const clamped = Math.max(GRID_SIZE_MIN, Math.min(GRID_SIZE_MAX, Math.round(v)));
+    setGridSizeState(clamped);
+    localStorage.setItem(GRID_SIZE_LS_KEY, String(clamped));
+  }, []);
+  const [scriptPreview, setScriptPreview] = useState<Point[][] | null>(null);
+
+  const value = useMemo<UICtx>(
+    () => ({
+      tool,
+      setTool,
+      polygonSides,
+      setPolygonSides,
+      starPoints,
+      setStarPoints,
+      zoom,
+      setZoom,
+      showGrid,
+      setShowGrid,
+      gridSize,
+      setGridSize,
+      drawColor,
+      setDrawColor,
+      scriptPreview,
+      setScriptPreview,
+    }),
+    [
+      tool,
+      polygonSides,
+      starPoints,
+      zoom,
+      showGrid,
+      gridSize,
+      setGridSize,
+      drawColor,
+      scriptPreview,
+    ],
+  );
+
+  return <UIContext.Provider value={value}>{children}</UIContext.Provider>;
+};
+
+export const useUI = () => {
+  const ctx = useContext(UIContext);
+  if (!ctx) throw new Error('useUI must be used within UIProvider');
+  return ctx;
+};

--- a/paint-app/src/vite-env.d.ts
+++ b/paint-app/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare module '*.css';

--- a/paint-app/tsconfig.app.json
+++ b/paint-app/tsconfig.app.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/paint-app/tsconfig.json
+++ b/paint-app/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/paint-app/tsconfig.node.json
+++ b/paint-app/tsconfig.node.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+
+    "skipLibCheck": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/paint-app/vite.config.ts
+++ b/paint-app/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary

Adds **paint-app**, a Vite + React + MUI single-page app for driving a Marlin-based pen plotter over Web Serial.

### Highlights
- **Setup/home screen** (non-modal): plotter selection, connect, project list, interactive session launch
- **Plotter calibration**: two-corner capture deriving bed size + X/Y orientation (handles mirrored axes)
- **Connection layer** (`serial.ts`): M115 liveness probe with fast-fail, inactivity-based `readUntilOk`, lossless line reader, device-loss detection, stale-port reopen handling
- **Global pause/resume**: gates all G-code output (print + interactive); clean resume, no lost position
- **Emergency stop (M112)**: fixed bottom-right button, kill-state detection, power-cycle recovery modal that returns home
- **Debug panel**: jog pad with center Home, pen up/down, bed extremes, always-on live position
- **Drawing**: per-stroke color (future strokes only), clear, fit-and-center interactive canvas, draggable auto-scroll log
- **Settings menu** refactored into per-item functional components driven by a declarative `MENUS` table (home/project/interactive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)